### PR TITLE
Ensure tests are run during Maven build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
         run: chmod +x hes/mvnw
 
       - name: Build with Maven
-        run: ./mvnw clean package -DskipTests
+        run: ./mvnw clean package 
         working-directory: hes
 
 


### PR DESCRIPTION
Removed the '-DskipTests' flag from Maven build command to ensure tests are executed during the build process.