### PR TITLE
Refactor DLMS Error Handling and Response Logic

### DIFF
--- a/hes/src/main/java/com/memmcol/hes/domain/clock/ClockWriteService.java
+++ b/hes/src/main/java/com/memmcol/hes/domain/clock/ClockWriteService.java
@@ -1,6 +1,7 @@
 package com.memmcol.hes.domain.clock;
 
 import com.memmcol.hes.infrastructure.dlms.DlmsReaderUtils;
+import com.memmcol.hes.model.DlmsResponse;
 import com.memmcol.hes.nettyUtils.SessionManagerMultiVendor;
 import gurux.dlms.GXDLMSClient;
 import gurux.dlms.GXDateTime;
@@ -41,12 +42,18 @@ public class ClockWriteService {
                 dateTime.atZone(ZoneId.systemDefault()).toInstant()
         ));
 
-        dlmsReaderUtils.writeAttribute(client, serial, clock, 2, gxDateTime);
+        DlmsResponse response = dlmsReaderUtils.writeAttribute(client, serial, clock, 2, gxDateTime);
 
         String formatted = dateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
-        String message = "🕒 Meter Clock for " + serial + " set to: " + formatted;
-        log.info(message);
-        return message;
+        if (response.isSuccess()) {
+            String message = "🕒 Meter Clock for " + serial + " set to: " + formatted;
+            log.info(message);
+            return message;
+        } else {
+            String message = "❌ Failed to set Meter Clock for " + serial + ": " + response.getMessage() + " (" + response.getStatus() + ")";
+            log.error(message);
+            return message;
+        }
     }
 
     public String setClockV1(String serial, LocalDateTime dateTime) throws Exception {
@@ -63,7 +70,13 @@ public class ClockWriteService {
 
         log.info("🕒 Initiating clock write → meter={}, targetTime={}", serial, dateTime);
 
-        dlmsReaderUtils.writeAttribute(client, serial, clock, 2, gxDateTime);
+        DlmsResponse response = dlmsReaderUtils.writeAttribute(client, serial, clock, 2, gxDateTime);
+
+        if (!response.isSuccess()) {
+            String message = "❌ Failed to set Meter Clock (V1) for " + serial + ": " + response.getMessage() + " (" + response.getStatus() + ")";
+            log.error(message);
+            return message;
+        }
 
         // 🔁 VERIFY (non-negotiable in DLMS writes)
         GXDateTime actual = readClock(client, serial);

--- a/hes/src/main/java/com/memmcol/hes/domain/network/NetworkWriteService.java
+++ b/hes/src/main/java/com/memmcol/hes/domain/network/NetworkWriteService.java
@@ -2,6 +2,7 @@ package com.memmcol.hes.domain.network;
 
 import com.memmcol.hes.application.port.out.MeterLockPort;
 import com.memmcol.hes.infrastructure.dlms.DlmsReaderUtils;
+import com.memmcol.hes.model.DlmsResponse;
 import com.memmcol.hes.nettyUtils.SessionManagerMultiVendor;
 import gurux.dlms.GXDLMSClient;
 import gurux.dlms.enums.DataType;
@@ -41,15 +42,21 @@ public class NetworkWriteService {
             log.info("Writing APN '{}' to meter {}", apn, meterSerial);
 
             // Class 45 (GPRS Setup), Attribute 2 (APN) is Octet String (DataType.OCTET_STRING)
-            dlmsReaderUtils.writeAttribute(client, meterSerial, "0.0.25.4.0.255", 45, 2,
+            DlmsResponse response = dlmsReaderUtils.writeAttribute(client, meterSerial, "0.0.25.4.0.255", 45, 2,
                     apn.getBytes(StandardCharsets.UTF_8), DataType.OCTET_STRING);
 
             Map<String, Object> result = new LinkedHashMap<>();
             result.put("meterSerial", meterSerial);
-            result.put("status", "success");
+            result.put("status", response.isSuccess() ? "success" : "failed");
+            result.put("dlmsStatus", response.getStatus());
+            result.put("message", response.getMessage());
             result.put("apn", apn);
 
-            log.info("✅ APN written successfully to meter {}", meterSerial);
+            if (response.isSuccess()) {
+                log.info("✅ APN written successfully to meter {}", meterSerial);
+            } else {
+                log.error("❌ Failed to write APN to meter {}: {} ({})", meterSerial, response.getMessage(), response.getStatus());
+            }
             return result;
         });
     }
@@ -74,15 +81,21 @@ public class NetworkWriteService {
                     .map(s -> s.getBytes(StandardCharsets.UTF_8))
                     .toList();
 
-            dlmsReaderUtils.writeAttribute(client, meterSerial, "0.0.2.1.0.255", 29, 6,
+            DlmsResponse response = dlmsReaderUtils.writeAttribute(client, meterSerial, "0.0.2.1.0.255", 29, 6,
                     octetStrings, DataType.ARRAY);
 
             Map<String, Object> result = new LinkedHashMap<>();
             result.put("meterSerial", meterSerial);
-            result.put("status", "success");
+            result.put("status", response.isSuccess() ? "success" : "failed");
+            result.put("dlmsStatus", response.getStatus());
+            result.put("message", response.getMessage());
             result.put("ipPorts", ipPorts);
 
-            log.info("✅ Destination List written successfully to meter {}", meterSerial);
+            if (response.isSuccess()) {
+                log.info("✅ Destination List written successfully to meter {}", meterSerial);
+            } else {
+                log.error("❌ Failed to write Destination List to meter {}: {} ({})", meterSerial, response.getMessage(), response.getStatus());
+            }
             return result;
         });
     }

--- a/hes/src/main/java/com/memmcol/hes/domain/profile/WriteCTPT.java
+++ b/hes/src/main/java/com/memmcol/hes/domain/profile/WriteCTPT.java
@@ -2,6 +2,8 @@ package com.memmcol.hes.domain.profile;
 
 import com.memmcol.hes.application.port.out.MeterLockPort;
 import com.memmcol.hes.infrastructure.dlms.DlmsReaderUtils;
+import com.memmcol.hes.model.DlmsResponse;
+import com.memmcol.hes.model.DlmsResponseStatus;
 import com.memmcol.hes.nettyUtils.SessionManagerMultiVendor;
 import gurux.dlms.enums.DataType;
 import gurux.dlms.GXDLMSClient;
@@ -49,27 +51,49 @@ public class WriteCTPT {
             // In Gurux Java this corresponds to DataType.UINT16 (16‑bit unsigned).
 
             // CT numerator: 1.0.0.4.2.255 attr 2
-            dlmsReaderUtils.writeAttribute(client, meterSerial, "1.0.0.4.2.255", 1, 2,
+            DlmsResponse ctNumResp = dlmsReaderUtils.writeAttribute(client, meterSerial, "1.0.0.4.2.255", 1, 2,
                     (int) ctNumerator, DataType.UINT16);
             result.put("ctNumerator", ctNumerator);
 
             // CT denominator: 1.0.0.4.5.255 attr 2
-            dlmsReaderUtils.writeAttribute(client, meterSerial, "1.0.0.4.5.255", 1, 2,
+            DlmsResponse ctDenResp = dlmsReaderUtils.writeAttribute(client, meterSerial, "1.0.0.4.5.255", 1, 2,
                     (int) ctDenominator, DataType.UINT16);
             result.put("ctDenominator", ctDenominator);
 
             // PT numerator: 1.0.0.4.3.255 attr 2
-            dlmsReaderUtils.writeAttribute(client, meterSerial, "1.0.0.4.3.255", 1, 2,
+            DlmsResponse ptNumResp = dlmsReaderUtils.writeAttribute(client, meterSerial, "1.0.0.4.3.255", 1, 2,
                     (int) ptNumerator, DataType.UINT16);
             result.put("ptNumerator", ptNumerator);
 
             // PT denominator: 1.0.0.4.6.255 attr 2
-            dlmsReaderUtils.writeAttribute(client, meterSerial, "1.0.0.4.6.255", 1, 2,
+            DlmsResponse ptDenResp = dlmsReaderUtils.writeAttribute(client, meterSerial, "1.0.0.4.6.255", 1, 2,
                     (int) ptDenominator, DataType.UINT16);
             result.put("ptDenominator", ptDenominator);
 
-            log.info("✅ CT/PT written meter={} ct={}/{} pt={}/{}",
-                    meterSerial, ctNumerator, ctDenominator, ptNumerator, ptDenominator);
+            boolean allSuccess = ctNumResp.isSuccess() && ctDenResp.isSuccess() && ptNumResp.isSuccess() && ptDenResp.isSuccess();
+
+            result.put("status", allSuccess ? "success" : "failed");
+
+            // If any failed, provide details. In a more complex scenario, we could provide details per OBIS.
+            if (!allSuccess) {
+                if (!ctNumResp.isSuccess()) {
+                    result.put("ctNumeratorError", ctNumResp.getMessage());
+                    result.put("dlmsStatus", ctNumResp.getStatus());
+                } else if (!ctDenResp.isSuccess()) {
+                    result.put("ctDenominatorError", ctDenResp.getMessage());
+                    result.put("dlmsStatus", ctDenResp.getStatus());
+                } else if (!ptNumResp.isSuccess()) {
+                    result.put("ptNumeratorError", ptNumResp.getMessage());
+                    result.put("dlmsStatus", ptNumResp.getStatus());
+                } else if (!ptDenResp.isSuccess()) {
+                    result.put("ptDenominatorError", ptDenResp.getMessage());
+                    result.put("dlmsStatus", ptDenResp.getStatus());
+                }
+                log.error("❌ Failed to write CT/PT to meter {}: {}", meterSerial, result);
+            } else {
+                log.info("✅ CT/PT written successfully meter={} ct={}/{} pt={}/{}",
+                        meterSerial, ctNumerator, ctDenominator, ptNumerator, ptDenominator);
+            }
 
             return result;
         });

--- a/hes/src/main/java/com/memmcol/hes/infrastructure/dlms/DlmsReaderUtils.java
+++ b/hes/src/main/java/com/memmcol/hes/infrastructure/dlms/DlmsReaderUtils.java
@@ -8,6 +8,8 @@ import com.memmcol.hes.domain.profile.ProfileRowGeneric;
 import com.memmcol.hes.dto.MeterDTO;
 import com.memmcol.hes.mocks.MockRequestResponseService;
 import com.memmcol.hes.mocks.MockRxDecoderWithReply;
+import com.memmcol.hes.model.DlmsResponse;
+import com.memmcol.hes.model.DlmsResponseStatus;
 import com.memmcol.hes.model.ModelProfileMetadata;
 import com.memmcol.hes.repository.MeterRepository;
 import com.memmcol.hes.nettyUtils.SessionManagerMultiVendor;
@@ -50,6 +52,7 @@ public class DlmsReaderUtils {
     private final TxRxService txRxService;
     private final MeterProfileStateRepository meterProfileStateRepository;
     private final MeterRepository meterRepository;
+    private final DlmsResponseDecoder responseDecoder;
 
     private record DlmsRangeWindow(LocalDateTime from, LocalDateTime to) {}
 
@@ -164,84 +167,122 @@ public class DlmsReaderUtils {
      * @param index  attribute index to write
      * @param value  value to write (e.g. GXDateTime for clock)
      */
-    public void writeAttributeV1(GXDLMSClient client, String serial, GXDLMSObject obj, int index, Object value) throws Exception {
-        // Populate the object's attribute with the value before issuing the write.
-        if (obj instanceof GXDLMSClock clock && value instanceof GXDateTime dt) {
-            clock.setTime(dt);
-        } else {
-            client.updateValue(obj, index, value);
+    public DlmsResponse writeAttributeV1(GXDLMSClient client, String serial, GXDLMSObject obj, int index, Object value) throws Exception {
+        try {
+            // Populate the object's attribute with the value before issuing the write.
+            if (obj instanceof GXDLMSClock clock && value instanceof GXDateTime dt) {
+                clock.setTime(dt);
+            } else {
+                client.updateValue(obj, index, value);
+            }
+
+            byte[][] request = client.write(obj, index);
+
+            byte[] response = txRxService.sendReceiveWithContext(serial, request[0], 20000);
+
+            if (sessionManager.isAssociationLost(response)) {
+                sessionManager.removeSession(serial);
+                throw new AssociationLostException();
+            }
+
+            GXReplyData reply = new GXReplyData();
+            client.getData(response, reply, null);
+
+            DlmsResponseStatus status = responseDecoder.decodeStatus(reply);
+            return DlmsResponse.builder()
+                    .status(status)
+                    .message(reply.getErrorMessage())
+                    .meterSerial(serial)
+                    .build();
+        } catch (java.net.SocketTimeoutException | java.util.concurrent.TimeoutException te) {
+            return DlmsResponse.builder()
+                    .status(DlmsResponseStatus.TIMEOUT)
+                    .message("Connection timeout: " + te.getMessage())
+                    .meterSerial(serial)
+                    .build();
+        } catch (Exception e) {
+            return DlmsResponse.builder()
+                    .status(DlmsResponseStatus.COMMUNICATION_ERROR)
+                    .message("Communication error: " + e.getMessage())
+                    .meterSerial(serial)
+                    .build();
         }
-
-        byte[][] request = client.write(obj, index);
-
-        byte[] response = txRxService.sendReceiveWithContext(serial, request[0], 20000);
-
-        if (sessionManager.isAssociationLost(response)) {
-            sessionManager.removeSession(serial);
-            throw new AssociationLostException();
-        }
-
-        GXReplyData reply = new GXReplyData();
-        client.getData(response, reply, null);
-        DlmsErrorUtils.checkError(reply, serial, "OBIS Write!");
     }
 
-    public void writeAttribute(GXDLMSClient client,
+    public DlmsResponse writeAttribute(GXDLMSClient client,
                                String serial,
                                GXDLMSObject obj,
                                int index,
                                Object value) throws Exception {
 
-        // 1. Apply value to object
-        if (obj instanceof GXDLMSClock clock && value instanceof GXDateTime dt) {
-            clock.setTime(dt);
-        } else {
-            client.updateValue(obj, index, value);
-        }
-
-        byte[][] requests = client.write(obj, index);
-
-        if (requests == null || requests.length == 0) {
-            throw new IllegalStateException("DLMS write generated no frames");
-        }
-
-        GXReplyData reply = new GXReplyData();
-
-        long start = System.currentTimeMillis();
-
-        for (int i = 0; i < requests.length; i++) {
-
-            byte[] requestFrame = requests[i];
-
-            log.debug("📤 DLMS TX [{} / {}] → meter={}, bytes={}",
-                    i + 1, requests.length, serial, toHex(requestFrame));
-
-            byte[] response = txRxService.sendReceiveWithContext(serial, requestFrame, 20000);
-
-            if (sessionManager.isAssociationLost(response)) {
-                sessionManager.removeSession(serial);
-                throw new AssociationLostException("Association lost during write → meter=" + serial);
+        try {
+            // 1. Apply value to object
+            if (obj instanceof GXDLMSClock clock && value instanceof GXDateTime dt) {
+                clock.setTime(dt);
+            } else {
+                client.updateValue(obj, index, value);
             }
 
-            processReply(client, serial, response, reply);
+            byte[][] requests = client.write(obj, index);
+
+            if (requests == null || requests.length == 0) {
+                throw new IllegalStateException("DLMS write generated no frames");
+            }
+
+            GXReplyData reply = new GXReplyData();
+
+            long start = System.currentTimeMillis();
+
+            for (int i = 0; i < requests.length; i++) {
+
+                byte[] requestFrame = requests[i];
+
+                log.debug("📤 DLMS TX [{} / {}] → meter={}, bytes={}",
+                        i + 1, requests.length, serial, toHex(requestFrame));
+
+                byte[] response = txRxService.sendReceiveWithContext(serial, requestFrame, 20000);
+
+                if (sessionManager.isAssociationLost(response)) {
+                    sessionManager.removeSession(serial);
+                    throw new AssociationLostException("Association lost during write → meter=" + serial);
+                }
+
+                processReply(client, serial, response, reply);
+            }
+
+            if (!reply.isComplete()) {
+                throw new IllegalStateException("Incomplete DLMS reply → meter=" + serial);
+            }
+
+            long duration = System.currentTimeMillis() - start;
+            log.info("✅ DLMS write completed → meter={}, duration={}ms", serial, duration);
+
+            DlmsResponseStatus status = responseDecoder.decodeStatus(reply);
+            return DlmsResponse.builder()
+                    .status(status)
+                    .message(reply.getErrorMessage())
+                    .meterSerial(serial)
+                    .build();
+        } catch (java.net.SocketTimeoutException | java.util.concurrent.TimeoutException te) {
+            return DlmsResponse.builder()
+                    .status(DlmsResponseStatus.TIMEOUT)
+                    .message("Connection timeout: " + te.getMessage())
+                    .meterSerial(serial)
+                    .build();
+        } catch (Exception e) {
+            return DlmsResponse.builder()
+                    .status(DlmsResponseStatus.COMMUNICATION_ERROR)
+                    .message("Communication error: " + e.getMessage())
+                    .meterSerial(serial)
+                    .build();
         }
-
-        if (!reply.isComplete()) {
-            throw new IllegalStateException("Incomplete DLMS reply → meter=" + serial);
-        }
-
-        DlmsErrorUtils.checkError(reply, serial, "OBIS Write");
-
-        long duration = System.currentTimeMillis() - start;
-
-        log.info("✅ DLMS write success → meter={}, duration={}ms", serial, duration);
     }
 
     /**
      * Writes a DLMS attribute value using an explicit DLMS DataType, via the logical name
      * and class id. Useful when the meter is strict about the DLMS type (e.g. CT/PT long unsigned).
      */
-    public void writeAttribute(GXDLMSClient client,
+    public DlmsResponse writeAttribute(GXDLMSClient client,
                                String serial,
                                String logicalName,
                                int classId,
@@ -249,18 +290,38 @@ public class DlmsReaderUtils {
                                Object value,
                                DataType dataType) throws Exception {
 
-        byte[][] request = client.write(logicalName, value, dataType, gurux.dlms.enums.ObjectType.forValue(classId), index);
+        try {
+            byte[][] request = client.write(logicalName, value, dataType, gurux.dlms.enums.ObjectType.forValue(classId), index);
 
-        byte[] response = txRxService.sendReceiveWithContext(serial, request[0], 20000);
+            byte[] response = txRxService.sendReceiveWithContext(serial, request[0], 20000);
 
-        if (sessionManager.isAssociationLost(response)) {
-            sessionManager.removeSession(serial);
-            throw new AssociationLostException();
+            if (sessionManager.isAssociationLost(response)) {
+                sessionManager.removeSession(serial);
+                throw new AssociationLostException();
+            }
+
+            GXReplyData reply = new GXReplyData();
+            client.getData(response, reply, null);
+
+            DlmsResponseStatus status = responseDecoder.decodeStatus(reply);
+            return DlmsResponse.builder()
+                    .status(status)
+                    .message(reply.getErrorMessage())
+                    .meterSerial(serial)
+                    .build();
+        } catch (java.net.SocketTimeoutException | java.util.concurrent.TimeoutException te) {
+            return DlmsResponse.builder()
+                    .status(DlmsResponseStatus.TIMEOUT)
+                    .message("Connection timeout: " + te.getMessage())
+                    .meterSerial(serial)
+                    .build();
+        } catch (Exception e) {
+            return DlmsResponse.builder()
+                    .status(DlmsResponseStatus.COMMUNICATION_ERROR)
+                    .message("Communication error: " + e.getMessage())
+                    .meterSerial(serial)
+                    .build();
         }
-
-        GXReplyData reply = new GXReplyData();
-        client.getData(response, reply, null);
-        DlmsErrorUtils.checkError(reply, serial, "OBIS Write!");
     }
 
     public Object readAttribute(GXDLMSClient client, String serial, GXDLMSObject obj, int index) throws Exception {

--- a/hes/src/main/java/com/memmcol/hes/infrastructure/dlms/DlmsResponseDecoder.java
+++ b/hes/src/main/java/com/memmcol/hes/infrastructure/dlms/DlmsResponseDecoder.java
@@ -1,0 +1,73 @@
+package com.memmcol.hes.infrastructure.dlms;
+
+import com.memmcol.hes.model.DlmsResponseStatus;
+import gurux.dlms.GXDLMSExceptionResponse;
+import gurux.dlms.GXReplyData;
+import gurux.dlms.enums.ErrorCode;
+import gurux.dlms.enums.ExceptionServiceError;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * Helper component to decode DLMS responses and map them to DlmsResponseStatus.
+ */
+@Component
+@Slf4j
+public class DlmsResponseDecoder {
+
+    /**
+     * Map Gurux GXReplyData status to DlmsResponseStatus.
+     *
+     * @param reply Gurux reply data
+     * @return corresponding DlmsResponseStatus
+     */
+    public DlmsResponseStatus decodeStatus(GXReplyData reply) {
+        if (reply == null) {
+            return DlmsResponseStatus.COMMUNICATION_ERROR;
+        }
+
+        if (reply.getError() != 0) {
+            log.warn("DLMS Error received: Code={}, Message={}", reply.getError(), reply.getErrorMessage());
+            ErrorCode errorCode = ErrorCode.forValue(reply.getError());
+            if (errorCode != null) {
+                return switch (errorCode) {
+                    case TEMPORARY_FAILURE -> DlmsResponseStatus.TEMPORARY_FAILURE;
+                    case READ_WRITE_DENIED -> DlmsResponseStatus.READ_WRITE_DENIED;
+                    case UNDEFINED_OBJECT -> DlmsResponseStatus.OBJECT_NOT_DEFINED;
+                    default -> DlmsResponseStatus.OTHER_ERROR;
+                };
+            }
+            return DlmsResponseStatus.OTHER_ERROR;
+        }
+
+        if (reply.getValue() instanceof GXDLMSExceptionResponse exceptionResponse) {
+            return decodeException(exceptionResponse);
+        }
+
+        return DlmsResponseStatus.SUCCESS;
+    }
+
+    /**
+     * Map DLMS ExceptionResponse to DlmsResponseStatus.
+     *
+     * @param exceptionResponse Gurux exception response
+     * @return corresponding DlmsResponseStatus
+     */
+    public DlmsResponseStatus decodeException(GXDLMSExceptionResponse exceptionResponse) {
+        if (exceptionResponse == null) {
+            return DlmsResponseStatus.SUCCESS;
+        }
+
+        ExceptionServiceError serviceError = exceptionResponse.getExceptionServiceError();
+        log.warn("DLMS Exception received: ServiceError={}", serviceError);
+
+        if (serviceError == null) {
+            return DlmsResponseStatus.OTHER_ERROR;
+        }
+
+        return switch (serviceError) {
+            case OPERATION_NOT_POSSIBLE -> DlmsResponseStatus.TEMPORARY_FAILURE;
+            default -> DlmsResponseStatus.OTHER_ERROR;
+        };
+    }
+}

--- a/hes/src/main/java/com/memmcol/hes/model/DlmsResponse.java
+++ b/hes/src/main/java/com/memmcol/hes/model/DlmsResponse.java
@@ -1,0 +1,26 @@
+package com.memmcol.hes.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+/**
+ * Data Transfer Object representing the response from a DLMS communication operation.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DlmsResponse {
+    private DlmsResponseStatus status;
+    private String message;
+    private String meterSerial;
+    private Map<String, Object> resultData;
+
+    public boolean isSuccess() {
+        return DlmsResponseStatus.SUCCESS.equals(status);
+    }
+}

--- a/hes/src/main/java/com/memmcol/hes/model/DlmsResponseStatus.java
+++ b/hes/src/main/java/com/memmcol/hes/model/DlmsResponseStatus.java
@@ -1,0 +1,14 @@
+package com.memmcol.hes.model;
+
+/**
+ * Enumeration of DLMS response statuses for meter communication operations.
+ */
+public enum DlmsResponseStatus {
+    SUCCESS,
+    TEMPORARY_FAILURE,
+    READ_WRITE_DENIED,
+    OBJECT_NOT_DEFINED,
+    COMMUNICATION_ERROR,
+    TIMEOUT,
+    OTHER_ERROR
+}

--- a/hes/src/test/java/com/memmcol/hes/domain/network/NetworkWriteServiceTest.java
+++ b/hes/src/test/java/com/memmcol/hes/domain/network/NetworkWriteServiceTest.java
@@ -2,6 +2,8 @@ package com.memmcol.hes.domain.network;
 
 import com.memmcol.hes.application.port.out.MeterLockPort;
 import com.memmcol.hes.infrastructure.dlms.DlmsReaderUtils;
+import com.memmcol.hes.model.DlmsResponse;
+import com.memmcol.hes.model.DlmsResponseStatus;
 import com.memmcol.hes.nettyUtils.SessionManagerMultiVendor;
 import gurux.dlms.GXDLMSClient;
 import gurux.dlms.enums.DataType;
@@ -53,29 +55,43 @@ public class NetworkWriteServiceTest {
     void testWriteApn() throws Exception {
         // Arrange
         String apn = "Internet.ng.airtel.com";
+        DlmsResponse response = DlmsResponse.builder()
+                .status(DlmsResponseStatus.SUCCESS)
+                .message("Success")
+                .meterSerial(serial)
+                .build();
         when(sessionManager.getOrCreateClient(serial)).thenReturn(dlmsClient);
+        when(dlmsReaderUtils.writeAttribute(eq(dlmsClient), eq(serial), eq("0.0.25.4.0.255"), eq(45), eq(2), any(byte[].class), eq(DataType.OCTET_STRING)))
+                .thenReturn(response);
 
         // Act
         Map<String, Object> result = networkWriteService.writeApn(serial, apn);
 
         // Assert
         assertEquals("success", result.get("status"));
+        assertEquals(DlmsResponseStatus.SUCCESS, result.get("dlmsStatus"));
         assertEquals(apn, result.get("apn"));
-        verify(dlmsReaderUtils).writeAttribute(eq(dlmsClient), eq(serial), eq("0.0.25.4.0.255"), eq(45), eq(2), any(byte[].class), eq(DataType.OCTET_STRING));
     }
 
     @Test
     void testWriteIpPort() throws Exception {
         // Arrange
         List<String> ipPorts = List.of("41.216.166.165:29064");
+        DlmsResponse response = DlmsResponse.builder()
+                .status(DlmsResponseStatus.SUCCESS)
+                .message("Success")
+                .meterSerial(serial)
+                .build();
         when(sessionManager.getOrCreateClient(serial)).thenReturn(dlmsClient);
+        when(dlmsReaderUtils.writeAttribute(eq(dlmsClient), eq(serial), eq("0.0.2.1.0.255"), eq(29), eq(6), anyList(), eq(DataType.ARRAY)))
+                .thenReturn(response);
 
         // Act
         Map<String, Object> result = networkWriteService.writeIpPort(serial, ipPorts);
 
         // Assert
         assertEquals("success", result.get("status"));
+        assertEquals(DlmsResponseStatus.SUCCESS, result.get("dlmsStatus"));
         assertEquals(ipPorts, result.get("ipPorts"));
-        verify(dlmsReaderUtils).writeAttribute(eq(dlmsClient), eq(serial), eq("0.0.2.1.0.255"), eq(29), eq(6), anyList(), eq(DataType.ARRAY));
     }
 }


### PR DESCRIPTION
This refactor replaces hardcoded "Success" statuses in DLMS write operations with a granular response model.

Key changes:
1.  **Standardized Statuses:** Created a new `DlmsResponseStatus` enum covering Success, Temporary Failure, Read-Write Denied, Object Not Defined, Timeout, and Communication Error.
2.  **Centralized Decoding:** Implemented `DlmsResponseDecoder` to translate Gurux-specific error codes and DLMS exceptions into the standardized project-level statuses.
3.  **Enhanced Infrastructure:** Modified `DlmsReaderUtils.writeAttribute` methods to catch communication exceptions (timeouts, connection issues) and return a structured `DlmsResponse`.
4.  **Service Propagation:** Updated `NetworkWriteService`, `WriteCTPT`, and `ClockWriteService` to consume the structured `DlmsResponse` and return detailed outcomes in their response maps/messages.
5.  **Robust Error Handling:** Added explicit try-catch blocks in the communication layer to differentiate between application-level DLMS errors and transport-level failures (like socket timeouts).

Note: Unrelated compilation failures in `MonthlyConsumptionServiceTest` were identified as pre-existing and out of scope, and were left untouched as per user instruction to ensure no unintended production impact on `MonthlyBillingEntity`.

---
*PR created automatically by Jules for task [2842276061797517173](https://jules.google.com/task/2842276061797517173) started by @oluwin*