### PR TITLE
feat: Improve real-time read handling with enhanced error tracking and event management

### DIFF
--- a/hes/src/main/java/com/memmcol/hes/gridflex/services/RealtimeReadSseService.java
+++ b/hes/src/main/java/com/memmcol/hes/gridflex/services/RealtimeReadSseService.java
@@ -233,6 +233,33 @@ public class RealtimeReadSseService {
 
         int success = 0;
         int failed = 0;
+        try {
+            List<Map<String, Object>> batchReadings = readMeterObisValuesBatch(meter, obisList, meterStarted);
+            for (Map<String, Object> reading : batchReadings) {
+                if (Thread.currentThread().isInterrupted() || !acceptingEvents.get()) {
+                    break;
+                }
+
+                if (Integer.valueOf(0).equals(reading.get("statuscode"))) {
+                    success++;
+                    totalSuccess.incrementAndGet();
+                } else {
+                    failed++;
+                    totalFailed.incrementAndGet();
+                }
+
+                send(emitter, "reading", reading);
+            }
+
+            long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - meterStarted);
+            log.info("✅ Batched realtime read meter={} finished success={} failed={} elapsedMs={}",
+                    meter.getMeterSerial(), success, failed, elapsedMs);
+            return new RealtimeReadSummary(success, failed);
+        } catch (Exception batchException) {
+            log.warn("⚠️ Batched realtime read failed for meter={}, falling back to single OBIS reads: {}",
+                    meter.getMeterSerial(), batchException.getMessage());
+        }
+
         for (ObisDto obis : obisList) {
             if (Thread.currentThread().isInterrupted() || !acceptingEvents.get()) {
                 break;
@@ -256,6 +283,32 @@ public class RealtimeReadSseService {
         log.info("✅ Realtime read meter={} finished success={} failed={} elapsedMs={}",
                 meter.getMeterSerial(), success, failed, elapsedMs);
         return new RealtimeReadSummary(success, failed);
+    }
+
+    private List<Map<String, Object>> readMeterObisValuesBatch(MeterDto meter,
+                                                               List<ObisDto> obisList,
+                                                               long meterStarted) throws Exception {
+        List<String> obisStrings = obisList.stream()
+                .map(ObisDto::getObisString)
+                .toList();
+        List<Map<String, Object>> batchResponses = trainingService.readObisValuesBatch(
+                meter.getMeterModel(), meter.getMeterSerial(), obisStrings, meter.isMD());
+        long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - meterStarted);
+        List<Map<String, Object>> readings = new ArrayList<>(batchResponses.size());
+
+        for (int i = 0; i < obisList.size(); i++) {
+            ObisDto obis = obisList.get(i);
+            Map<String, Object> response = batchResponses.get(i);
+            Map<String, Object> responseData = basePayload(meter, obis.getObisString());
+            responseData.put("desc", mapObisCode(obis.getObisString()));
+            responseData.put("value", extractValue(response));
+            responseData.put("statusmessage", "SUCCESS");
+            responseData.put("elapsedMs", elapsedMs);
+            responseData.put("batch", true);
+            readings.add(responseData);
+        }
+
+        return readings;
     }
 
     private Map<String, Object> readSingleObis(MeterDto meter, ObisDto obis) {

--- a/hes/src/main/java/com/memmcol/hes/gridflex/services/RealtimeReadSseService.java
+++ b/hes/src/main/java/com/memmcol/hes/gridflex/services/RealtimeReadSseService.java
@@ -28,6 +28,8 @@ import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 @Service
@@ -65,7 +67,7 @@ public class RealtimeReadSseService {
 
     public SseEmitter streamRealtimeRead(RealtimeReadRequest request) {
         RealtimeReadPlan plan = buildPlan(request);
-        SseEmitter emitter = new SseEmitter(requestTimeout.toMillis());
+        SseEmitter emitter = new SseEmitter(requestTimeout.plusSeconds(5).toMillis());
 
         streamExecutor.execute(() -> {
             try {
@@ -162,17 +164,19 @@ public class RealtimeReadSseService {
 
     private RealtimeReadSummary executeRealtimeRead(RealtimeReadPlan plan, SseEmitter emitter)
             throws InterruptedException, IOException {
-        CompletionService<List<Map<String, Object>>> completionService =
+        CompletionService<RealtimeReadSummary> completionService =
                 new ExecutorCompletionService<>(realtimeReadExecutor);
-        List<Future<List<Map<String, Object>>>> submitted = new ArrayList<>(plan.meters().size());
+        List<Future<RealtimeReadSummary>> submitted = new ArrayList<>(plan.meters().size());
+        AtomicBoolean acceptingEvents = new AtomicBoolean(true);
+        AtomicInteger success = new AtomicInteger();
+        AtomicInteger failed = new AtomicInteger();
 
         for (MeterDto meter : plan.meters()) {
-            submitted.add(completionService.submit(() -> readMeterObisValues(meter, plan.obisList())));
+            submitted.add(completionService.submit(() -> readMeterObisValues(
+                    meter, plan.obisList(), emitter, acceptingEvents, success, failed)));
         }
 
         int completedMeters = 0;
-        int success = 0;
-        int failed = 0;
         long deadlineNanos = System.nanoTime() + requestTimeout.toNanos();
 
         try {
@@ -182,56 +186,81 @@ public class RealtimeReadSseService {
                     break;
                 }
 
-                Future<List<Map<String, Object>>> future = completionService.poll(remainingNanos, TimeUnit.NANOSECONDS);
+                Future<RealtimeReadSummary> future = completionService.poll(remainingNanos, TimeUnit.NANOSECONDS);
                 if (future == null) {
                     break;
                 }
 
                 completedMeters++;
                 try {
-                    List<Map<String, Object>> readings = future.get();
-                    for (Map<String, Object> reading : readings) {
-                        if (Integer.valueOf(0).equals(reading.get("statuscode"))) {
-                            success++;
-                        } else {
-                            failed++;
-                        }
-                        send(emitter, "reading", reading);
-                    }
+                    future.get();
                 } catch (ExecutionException ex) {
-                    failed += plan.obisList().size();
+                    failed.addAndGet(plan.obisList().size());
                     send(emitter, "reading", errorPayload(null, null, ex.getMessage()));
                 }
             }
 
             int timedOutMeters = submitted.size() - completedMeters;
             if (timedOutMeters > 0) {
+                acceptingEvents.set(false);
                 cancelPending(submitted);
-                failed += timedOutMeters * plan.obisList().size();
+                int expectedReadings = plan.meters().size() * plan.obisList().size();
+                int pendingReadings = expectedReadings - success.get() - failed.get();
+                if (pendingReadings > 0) {
+                    failed.addAndGet(pendingReadings);
+                }
                 send(emitter, "warning", Map.of(
                         "statusmessage", "Realtime read timed out.",
                         "timedOutMeters", timedOutMeters
                 ));
             }
 
-            return new RealtimeReadSummary(success, failed);
+            return new RealtimeReadSummary(success.get(), failed.get());
         } finally {
+            acceptingEvents.set(false);
             cancelPending(submitted);
         }
     }
 
-    private List<Map<String, Object>> readMeterObisValues(MeterDto meter, List<ObisDto> obisList) {
+    private RealtimeReadSummary readMeterObisValues(MeterDto meter,
+                                                    List<ObisDto> obisList,
+                                                    SseEmitter emitter,
+                                                    AtomicBoolean acceptingEvents,
+                                                    AtomicInteger totalSuccess,
+                                                    AtomicInteger totalFailed) throws IOException {
+        long meterStarted = System.nanoTime();
         log.info("⚙️ Realtime read meter={}, obisCount={}", meter.getMeterSerial(), obisList.size());
 
-        List<Map<String, Object>> readings = new ArrayList<>(obisList.size());
+        int success = 0;
+        int failed = 0;
         for (ObisDto obis : obisList) {
-            readings.add(readSingleObis(meter, obis));
+            if (Thread.currentThread().isInterrupted() || !acceptingEvents.get()) {
+                break;
+            }
+
+            Map<String, Object> reading = readSingleObis(meter, obis);
+            if (Integer.valueOf(0).equals(reading.get("statuscode"))) {
+                success++;
+                totalSuccess.incrementAndGet();
+            } else {
+                failed++;
+                totalFailed.incrementAndGet();
+            }
+
+            if (acceptingEvents.get()) {
+                send(emitter, "reading", reading);
+            }
         }
-        return readings;
+
+        long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - meterStarted);
+        log.info("✅ Realtime read meter={} finished success={} failed={} elapsedMs={}",
+                meter.getMeterSerial(), success, failed, elapsedMs);
+        return new RealtimeReadSummary(success, failed);
     }
 
     private Map<String, Object> readSingleObis(MeterDto meter, ObisDto obis) {
         Map<String, Object> responseData = basePayload(meter, obis.getObisString());
+        long started = System.nanoTime();
 
         try {
             Object value;
@@ -254,6 +283,8 @@ public class RealtimeReadSseService {
             responseData.put("statuscode", -1);
             responseData.put("value", null);
             responseData.put("statusmessage", e.getMessage());
+        } finally {
+            responseData.put("elapsedMs", TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - started));
         }
 
         return responseData;
@@ -320,7 +351,6 @@ public class RealtimeReadSseService {
     private String mapObisCode(String obisCode) {
 
         if (obisCode == null) return null;
-        System.out.println(">>>>:"+obisCode);
 
         switch (obisCode) {
 

--- a/hes/src/main/java/com/memmcol/hesTraining/services/MeterReadingService.java
+++ b/hes/src/main/java/com/memmcol/hesTraining/services/MeterReadingService.java
@@ -26,9 +26,12 @@ import java.text.DecimalFormat;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.AbstractMap;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 @Service
@@ -608,6 +611,231 @@ public class MeterReadingService {
         }
     }
 
+    public List<Map<String, Object>> readObisValuesBatch(String meterModel,
+                                                         String meterSerial,
+                                                         List<String> obisList,
+                                                         boolean mdMeter) throws Exception {
+        if (obisList == null || obisList.isEmpty()) {
+            return List.of();
+        }
+
+        GXDLMSClient client = sessionManagerMultiVendor.getOrCreateClient(meterSerial);
+        if (client == null) {
+            throw new IllegalStateException("No active session for meter: " + meterSerial);
+        }
+
+        List<ParsedObis> parsedObis = new ArrayList<>(obisList.size());
+        for (String obis : obisList) {
+            parsedObis.add(parseObis(obis));
+        }
+
+        readScalerUnitsBatch(client, meterSerial, parsedObis);
+
+        List<Map.Entry<GXDLMSObject, Integer>> valueReads = parsedObis.stream()
+                .<Map.Entry<GXDLMSObject, Integer>>map(parsed -> new AbstractMap.SimpleEntry<>(parsed.object(), parsed.attributeIndex()))
+                .toList();
+
+        List<Object> values = readListValues(client, meterSerial, valueReads);
+        if (values.size() != parsedObis.size()) {
+            throw new IllegalStateException("Batched OBIS read returned " + values.size()
+                    + " value(s) for " + parsedObis.size() + " requested OBIS code(s).");
+        }
+
+        MeterRatios meterRatios = mdMeter ? ratioService.readMeterRatios(meterModel, meterSerial) : null;
+        DecimalFormat formatter = new DecimalFormat("#,##0.00");
+        List<Map<String, Object>> response = new ArrayList<>(parsedObis.size());
+
+        for (int i = 0; i < parsedObis.size(); i++) {
+            ParsedObis parsed = parsedObis.get(i);
+            Object rawValue = values.get(i);
+            Object formattedValue = formatBatchValue(parsed, rawValue, mdMeter, meterRatios, formatter);
+
+            Map<String, Object> item = new LinkedHashMap<>();
+            item.put("Meter No", meterSerial);
+            item.put("obisCode", parsed.obisCode());
+            item.put("attributeIndex", parsed.attributeIndex());
+            item.put("dataIndex", parsed.dataIndex());
+            item.put(mdMeter ? "Raw Value" : "value", rawValue);
+            item.put("Actual Value", formattedValue);
+            if (parsed.object() instanceof GXDLMSRegister register) {
+                item.put("scaler", register.getScaler() == 0 ? 1.0 : register.getScaler());
+                item.put("unit", getUnitSymbol(register.getUnit()));
+            } else if (parsed.object() instanceof GXDLMSExtendedRegister register) {
+                item.put("scaler", register.getScaler() == 0 ? 1.0 : register.getScaler());
+                item.put("unit", getUnitSymbol(register.getUnit()));
+            } else if (parsed.object() instanceof GXDLMSDemandRegister register) {
+                item.put("scaler", register.getScaler() == 0 ? 1.0 : register.getScaler());
+                item.put("unit", getUnitSymbol(register.getUnit()));
+            }
+            response.add(item);
+        }
+
+        return response;
+    }
+
+    private void readScalerUnitsBatch(GXDLMSClient client, String meterSerial, List<ParsedObis> parsedObis) throws Exception {
+        List<ParsedObis> scalerReads = parsedObis.stream()
+                .filter(parsed -> supportsScalerUnit(parsed.objectType()))
+                .toList();
+        if (scalerReads.isEmpty()) {
+            return;
+        }
+
+        List<Map.Entry<GXDLMSObject, Integer>> reads = scalerReads.stream()
+                .<Map.Entry<GXDLMSObject, Integer>>map(parsed -> new AbstractMap.SimpleEntry<>(parsed.object(), 3))
+                .toList();
+        List<Object> scalerValues = readListValues(client, meterSerial, reads);
+        if (scalerValues.size() != scalerReads.size()) {
+            throw new IllegalStateException("Batched scaler/unit read returned " + scalerValues.size()
+                    + " value(s) for " + scalerReads.size() + " requested OBIS code(s).");
+        }
+
+        for (int i = 0; i < scalerReads.size(); i++) {
+            client.updateValue(scalerReads.get(i).object(), 3, scalerValues.get(i));
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Object> readListValues(GXDLMSClient client,
+                                        String meterSerial,
+                                        List<Map.Entry<GXDLMSObject, Integer>> reads) throws Exception {
+        byte[][] requests = client.readList(reads);
+        GXReplyData reply = new GXReplyData();
+
+        byte[] response = txRxService.sendReceiveWithContext(meterSerial, requests[0], 20000);
+        if (sessionManagerMultiVendor.isAssociationLost(response)) {
+            sessionManagerMultiVendor.removeSession(meterSerial);
+            throw new AssociationLostException("Association lost during batched OBIS read");
+        }
+
+        client.getData(response, reply, null);
+        Object value = reply.getValue();
+        if (value instanceof List<?> list) {
+            return (List<Object>) list;
+        }
+        if (reads.size() == 1) {
+            return List.of(value);
+        }
+        throw new IllegalStateException("Batched OBIS read response was not a value list.");
+    }
+
+    private ParsedObis parseObis(String obis) {
+        String[] parts = obis.split(";");
+        if (parts.length != 4) {
+            throw new IllegalArgumentException("OBIS format must be: classId;obisCode;attributeIndex;dataIndex");
+        }
+
+        int classId = Integer.parseInt(parts[0]);
+        String obisCode = parts[1].trim();
+        int attributeIndex = Integer.parseInt(parts[2]);
+        int dataIndex = Integer.parseInt(parts[3]);
+        ObjectType objectType = ObjectType.forValue(classId);
+        GXDLMSObject object = createObject(objectType, obisCode);
+        return new ParsedObis(obis, obisCode, classId, attributeIndex, dataIndex, objectType, object);
+    }
+
+    private GXDLMSObject createObject(ObjectType objectType, String obisCode) {
+        GXDLMSObject object = switch (objectType) {
+            case REGISTER -> new GXDLMSRegister();
+            case EXTENDED_REGISTER -> new GXDLMSExtendedRegister();
+            case DEMAND_REGISTER -> new GXDLMSDemandRegister();
+            case CLOCK -> new GXDLMSClock();
+            case DATA -> new GXDLMSData();
+            default -> GXDLMSClient.createObject(objectType);
+        };
+        object.setLogicalName(obisCode);
+        return object;
+    }
+
+    private Object formatBatchValue(ParsedObis parsed,
+                                    Object rawValue,
+                                    boolean mdMeter,
+                                    MeterRatios meterRatios,
+                                    DecimalFormat formatter) {
+        if (rawValue == null) {
+            return null;
+        }
+
+        ObjectType type = parsed.objectType();
+        if (type == ObjectType.CLOCK) {
+            return formatClock(rawValue);
+        }
+        if (rawValue instanceof byte[] bytes) {
+            return DlmsDataDecoder.decodeOctetString(bytes);
+        }
+        if (!(rawValue instanceof Number)) {
+            return rawValue.toString();
+        }
+
+        BigDecimal finalValue = new BigDecimal(rawValue.toString());
+        if (supportsScalerUnit(type)) {
+            String unitSymbol = getRegisterUnit(parsed.object());
+            if (mdMeter && meterRatios != null) {
+                finalValue = applyMdRatio(finalValue, unitSymbol, meterRatios);
+            } else if (isPowerOrEnergy(unitSymbol)) {
+                finalValue = finalValue.divide(new BigDecimal(1000), 2, RoundingMode.HALF_UP);
+            } else {
+                finalValue = finalValue.setScale(2, RoundingMode.HALF_UP);
+            }
+            return formatter.format(finalValue);
+        }
+
+        return finalValue.toString();
+    }
+
+    private String formatClock(Object rawValue) {
+        GXDateTime clockDateTime;
+        if (rawValue instanceof GXDateTime dt) {
+            clockDateTime = dt;
+        } else if (rawValue instanceof byte[] array) {
+            clockDateTime = GXCommon.getDateTime(array);
+        } else {
+            return rawValue.toString();
+        }
+        LocalDateTime localDateTime = clockDateTime.getMeterCalendar().toInstant()
+                .atZone(ZoneId.systemDefault())
+                .toLocalDateTime();
+        return localDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+    }
+
+    private BigDecimal applyMdRatio(BigDecimal value, String unitSymbol, MeterRatios meterRatios) {
+        return switch (unitSymbol) {
+            case "A" -> value.multiply(BigDecimal.valueOf(meterRatios.getCtRatio()))
+                    .setScale(2, RoundingMode.HALF_UP);
+            case "V" -> value.multiply(BigDecimal.valueOf(meterRatios.getPtRatio()))
+                    .setScale(2, RoundingMode.HALF_UP);
+            case "KW", "KVA", "KVar", "KWh", "KVAh", "KVarh" -> value.multiply(BigDecimal.valueOf(meterRatios.getCtRatio()))
+                    .divide(new BigDecimal(1000), 2, RoundingMode.HALF_UP);
+            default -> value.setScale(2, RoundingMode.HALF_UP);
+        };
+    }
+
+    private String getRegisterUnit(GXDLMSObject object) {
+        if (object instanceof GXDLMSRegister register) {
+            return getUnitSymbol(register.getUnit());
+        }
+        if (object instanceof GXDLMSExtendedRegister register) {
+            return getUnitSymbol(register.getUnit());
+        }
+        if (object instanceof GXDLMSDemandRegister register) {
+            return getUnitSymbol(register.getUnit());
+        }
+        return "";
+    }
+
+    private boolean supportsScalerUnit(ObjectType type) {
+        return type == ObjectType.REGISTER
+                || type == ObjectType.EXTENDED_REGISTER
+                || type == ObjectType.DEMAND_REGISTER;
+    }
+
+    private boolean isPowerOrEnergy(String unitSymbol) {
+        return switch (unitSymbol) {
+            case "KW", "KVA", "KVar", "KWh", "KVAh", "KVarh" -> true;
+            default -> false;
+        };
+    }
+
     static public String getUnitSymbol(Unit unit) {
         return switch (unit) {
             case VOLTAGE -> "V";
@@ -622,6 +850,15 @@ public class MeterReadingService {
             // Add more cases as needed
             default -> unit.name(); // fallback to enum name
         };
+    }
+
+    private record ParsedObis(String obis,
+                              String obisCode,
+                              int classId,
+                              int attributeIndex,
+                              int dataIndex,
+                              ObjectType objectType,
+                              GXDLMSObject object) {
     }
 
 }


### PR DESCRIPTION
## Summary

Improves realtime OBIS SSE reads by streaming each OBIS result as soon as it finishes instead of waiting for all reads for a meter to complete. This makes slow realtime reads feel more responsive and helps avoid the UI appearing stuck during long DLMS operations.

Also adds per-OBIS `elapsedMs` timing to the emitted payload and meter-level timing logs to help identify slow OBIS codes or meters.
Added MeterReadingService.readObisValuesBatch(...) using Gurux readList(...).
For register-like OBIS codes, it batches scaler/unit reads first, then batches value reads.
Realtime now tries the batched path per meter first.
If a meter rejects batching or returns an unexpected response, it falls back to the old one-by-one OBIS reads.
Batched SSE payloads include "batch": true and elapsedMs.
