### PR TITLE
feat: Add fallback option for single OBIS reads and enhance error handling in MeterReadingService

### DIFF
--- a/hes/src/main/java/com/memmcol/hes/gridflex/services/RealtimeReadSseService.java
+++ b/hes/src/main/java/com/memmcol/hes/gridflex/services/RealtimeReadSseService.java
@@ -44,6 +44,7 @@ public class RealtimeReadSseService {
     private final Duration requestTimeout;
     private final String fallbackMdModel;
     private final String fallbackNonMdModel;
+    private final boolean fallbackToSingleObis;
 
     public RealtimeReadSseService(MeterReadingService trainingService,
                                   MeterRepository meterRepository,
@@ -53,7 +54,8 @@ public class RealtimeReadSseService {
                                   @Value("${hes.realtime-read.max-obis:20}") int maxObisPerRequest,
                                   @Value("${hes.realtime-read.timeout-seconds:120}") long requestTimeoutSeconds,
                                   @Value("${hes.realtime-read.fallback-md-model:MDModelX}") String fallbackMdModel,
-                                  @Value("${hes.realtime-read.fallback-non-md-model:NonMDModelX}") String fallbackNonMdModel) {
+                                  @Value("${hes.realtime-read.fallback-non-md-model:NonMDModelX}") String fallbackNonMdModel,
+                                  @Value("${hes.realtime-read.fallback-to-single-obis:false}") boolean fallbackToSingleObis) {
         this.trainingService = trainingService;
         this.meterRepository = meterRepository;
         this.streamExecutor = streamExecutor;
@@ -63,6 +65,7 @@ public class RealtimeReadSseService {
         this.requestTimeout = Duration.ofSeconds(Math.max(1, requestTimeoutSeconds));
         this.fallbackMdModel = fallbackMdModel;
         this.fallbackNonMdModel = fallbackNonMdModel;
+        this.fallbackToSingleObis = fallbackToSingleObis;
     }
 
     public SseEmitter streamRealtimeRead(RealtimeReadRequest request) {
@@ -256,8 +259,34 @@ public class RealtimeReadSseService {
                     meter.getMeterSerial(), success, failed, elapsedMs);
             return new RealtimeReadSummary(success, failed);
         } catch (Exception batchException) {
-            log.warn("⚠️ Batched realtime read failed for meter={}, falling back to single OBIS reads: {}",
+            log.warn("⚠️ Batched realtime read failed for meter={}: {}",
                     meter.getMeterSerial(), batchException.getMessage());
+            if (!fallbackToSingleObis) {
+                String message = "Batched realtime read failed: " + batchException.getMessage();
+                for (ObisDto obis : obisList) {
+                    if (Thread.currentThread().isInterrupted() || !acceptingEvents.get()) {
+                        break;
+                    }
+
+                    Map<String, Object> reading = basePayload(meter, obis.getObisString());
+                    reading.put("desc", mapObisCode(obis.getObisString()));
+                    reading.put("statuscode", -1);
+                    reading.put("value", null);
+                    reading.put("statusmessage", message);
+                    reading.put("elapsedMs", TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - meterStarted));
+                    reading.put("batch", true);
+                    failed++;
+                    totalFailed.incrementAndGet();
+                    send(emitter, "reading", reading);
+                }
+
+                log.info("✅ Batched realtime read meter={} failed fast failed={} elapsedMs={}",
+                        meter.getMeterSerial(), failed,
+                        TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - meterStarted));
+                return new RealtimeReadSummary(success, failed);
+            }
+
+            log.warn("⚠️ Falling back to single OBIS reads for meter={}", meter.getMeterSerial());
         }
 
         for (ObisDto obis : obisList) {
@@ -301,8 +330,14 @@ public class RealtimeReadSseService {
             Map<String, Object> response = batchResponses.get(i);
             Map<String, Object> responseData = basePayload(meter, obis.getObisString());
             responseData.put("desc", mapObisCode(obis.getObisString()));
-            responseData.put("value", extractValue(response));
-            responseData.put("statusmessage", "SUCCESS");
+            if (Integer.valueOf(-1).equals(response.get("statuscode")) || response.containsKey("error")) {
+                responseData.put("statuscode", -1);
+                responseData.put("value", null);
+                responseData.put("statusmessage", String.valueOf(response.getOrDefault("error", "Batched OBIS read failed")));
+            } else {
+                responseData.put("value", extractValue(response));
+                responseData.put("statusmessage", "SUCCESS");
+            }
             responseData.put("elapsedMs", elapsedMs);
             responseData.put("batch", true);
             readings.add(responseData);

--- a/hes/src/main/java/com/memmcol/hesTraining/services/MeterReadingService.java
+++ b/hes/src/main/java/com/memmcol/hesTraining/services/MeterReadingService.java
@@ -9,6 +9,7 @@ import com.memmcol.hes.exception.AssociationLostException;
 import com.memmcol.hes.service.MeterRatioService;
 import gurux.dlms.*;
 import gurux.dlms.enums.Authentication;
+import gurux.dlms.enums.ErrorCode;
 import gurux.dlms.enums.InterfaceType;
 import gurux.dlms.enums.ObjectType;
 import gurux.dlms.enums.Unit;
@@ -636,27 +637,17 @@ public class MeterReadingService {
                 .toList();
 
         List<Object> values = readListValues(client, meterSerial, valueReads);
-        if (values.size() != parsedObis.size()) {
-            throw new IllegalStateException("Batched OBIS read returned " + values.size()
-                    + " value(s) for " + parsedObis.size() + " requested OBIS code(s).");
-        }
-
         MeterRatios meterRatios = mdMeter ? ratioService.readMeterRatios(meterModel, meterSerial) : null;
         DecimalFormat formatter = new DecimalFormat("#,##0.00");
         List<Map<String, Object>> response = new ArrayList<>(parsedObis.size());
 
         for (int i = 0; i < parsedObis.size(); i++) {
             ParsedObis parsed = parsedObis.get(i);
-            Object rawValue = values.get(i);
-            Object formattedValue = formatBatchValue(parsed, rawValue, mdMeter, meterRatios, formatter);
-
             Map<String, Object> item = new LinkedHashMap<>();
             item.put("Meter No", meterSerial);
             item.put("obisCode", parsed.obisCode());
             item.put("attributeIndex", parsed.attributeIndex());
             item.put("dataIndex", parsed.dataIndex());
-            item.put(mdMeter ? "Raw Value" : "value", rawValue);
-            item.put("Actual Value", formattedValue);
             if (parsed.object() instanceof GXDLMSRegister register) {
                 item.put("scaler", register.getScaler() == 0 ? 1.0 : register.getScaler());
                 item.put("unit", getUnitSymbol(register.getUnit()));
@@ -666,6 +657,34 @@ public class MeterReadingService {
             } else if (parsed.object() instanceof GXDLMSDemandRegister register) {
                 item.put("scaler", register.getScaler() == 0 ? 1.0 : register.getScaler());
                 item.put("unit", getUnitSymbol(register.getUnit()));
+            }
+
+            if (i >= values.size()) {
+                item.put("statuscode", -1);
+                item.put("error", "No DLMS value returned for this OBIS in batched response");
+                item.put("Actual Value", null);
+                response.add(item);
+                continue;
+            }
+
+            Object rawValue = unwrapBatchValue(values.get(i));
+            if (isDlmsFailure(rawValue)) {
+                item.put("statuscode", -1);
+                item.put("error", dlmsFailureMessage(rawValue));
+                item.put("Actual Value", null);
+                response.add(item);
+                continue;
+            }
+
+            try {
+                Object formattedValue = formatBatchValue(parsed, rawValue, mdMeter, meterRatios, formatter);
+                item.put("statuscode", 0);
+                item.put(mdMeter ? "Raw Value" : "value", rawValue);
+                item.put("Actual Value", formattedValue);
+            } catch (Exception ex) {
+                item.put("statuscode", -1);
+                item.put("error", "Failed to format batched OBIS value: " + ex.getMessage());
+                item.put("Actual Value", null);
             }
             response.add(item);
         }
@@ -685,13 +704,25 @@ public class MeterReadingService {
                 .<Map.Entry<GXDLMSObject, Integer>>map(parsed -> new AbstractMap.SimpleEntry<>(parsed.object(), 3))
                 .toList();
         List<Object> scalerValues = readListValues(client, meterSerial, reads);
-        if (scalerValues.size() != scalerReads.size()) {
-            throw new IllegalStateException("Batched scaler/unit read returned " + scalerValues.size()
-                    + " value(s) for " + scalerReads.size() + " requested OBIS code(s).");
-        }
 
         for (int i = 0; i < scalerReads.size(); i++) {
-            client.updateValue(scalerReads.get(i).object(), 3, scalerValues.get(i));
+            if (i >= scalerValues.size()) {
+                log.warn("Batched scaler/unit read returned no value for meter={} obis={}",
+                        meterSerial, scalerReads.get(i).obisCode());
+                continue;
+            }
+            Object scalerValue = unwrapBatchValue(scalerValues.get(i));
+            if (isDlmsFailure(scalerValue)) {
+                log.warn("Batched scaler/unit read failed for meter={} obis={}: {}",
+                        meterSerial, scalerReads.get(i).obisCode(), dlmsFailureMessage(scalerValue));
+                continue;
+            }
+            try {
+                client.updateValue(scalerReads.get(i).object(), 3, scalerValue);
+            } catch (Exception ex) {
+                log.warn("Failed to apply batched scaler/unit for meter={} obis={}: {}",
+                        meterSerial, scalerReads.get(i).obisCode(), ex.getMessage());
+            }
         }
     }
 
@@ -717,6 +748,50 @@ public class MeterReadingService {
             return List.of(value);
         }
         throw new IllegalStateException("Batched OBIS read response was not a value list.");
+    }
+
+    private Object unwrapBatchValue(Object value) {
+        if (value instanceof GXDLMSAccessItem accessItem) {
+            if (accessItem.getError() != null && accessItem.getError() != ErrorCode.OK) {
+                return accessItem;
+            }
+            return accessItem.getValue();
+        }
+        return value;
+    }
+
+    private boolean isDlmsFailure(Object value) {
+        if (value instanceof GXDLMSExceptionResponse) {
+            return true;
+        }
+        if (value instanceof GXDLMSAccessItem accessItem) {
+            return accessItem.getError() != null && accessItem.getError() != ErrorCode.OK;
+        }
+        if (value instanceof ErrorCode errorCode) {
+            return errorCode != ErrorCode.OK;
+        }
+        if (value instanceof Map<?, ?> map) {
+            return map.containsKey("error");
+        }
+        return false;
+    }
+
+    private String dlmsFailureMessage(Object value) {
+        if (value instanceof GXDLMSExceptionResponse exceptionResponse) {
+            return "DLMS exception response: state=" + exceptionResponse.getStateError()
+                    + ", service=" + exceptionResponse.getExceptionServiceError()
+                    + ", value=" + exceptionResponse.getValue();
+        }
+        if (value instanceof GXDLMSAccessItem accessItem) {
+            return "DLMS access error: " + accessItem.getError();
+        }
+        if (value instanceof ErrorCode errorCode) {
+            return "DLMS access error: " + errorCode;
+        }
+        if (value instanceof Map<?, ?> map && map.containsKey("error")) {
+            return String.valueOf(map.get("error"));
+        }
+        return "DLMS access error";
     }
 
     private ParsedObis parseObis(String obis) {

--- a/hes/src/main/resources/application.properties
+++ b/hes/src/main/resources/application.properties
@@ -44,6 +44,7 @@ hes.realtime-read.timeout-seconds=120
 hes.realtime-read.stream-executor.size=10
 hes.realtime-read.fallback-md-model=MDModelX
 hes.realtime-read.fallback-non-md-model=NonMDModelX
+hes.realtime-read.fallback-to-single-obis=false
 
 #============================================================================
 # Job Interval Configuration


### PR DESCRIPTION
Improves realtime OBIS reads by using batched DLMS reads more safely and avoiding slow fallback behavior.

Changes:

Added batched realtime read handling for multiple OBIS values per meter.
Added per-OBIS partial failure support inside batch responses.
Preserves successful OBIS readings when some items fail.
Marks failed OBIS items individually with statuscode: -1, value: null, and an error statusmessage.
Added batch: true and elapsedMs metadata to batched reading events.
Added hes.realtime-read.fallback-to-single-obis=false to prevent slow one-by-one fallback after batch failure.

Why:
Realtime reads were slow because failed or slow OBIS reads could trigger sequential fallback reads, causing long waits and timeouts. This keeps the batch speed benefit, returns partial successful data, and fails fast when the whole batch cannot be read.