### PR TITLE
feat: Enhance error handling in RealtimeReadSseService and improve MeterReadingService with caching and timeout adjustments

### DIFF
--- a/hes/src/main/java/com/memmcol/hes/gridflex/services/RealtimeReadSseService.java
+++ b/hes/src/main/java/com/memmcol/hes/gridflex/services/RealtimeReadSseService.java
@@ -93,7 +93,18 @@ public class RealtimeReadSseService {
                 emitter.complete();
             } catch (Exception e) {
                 log.error("❌ Unexpected realtime read error: {}", e.getMessage());
-                emitter.completeWithError(e);
+                // Best-effort terminal event so the FE never waits indefinitely.
+                try {
+                    emitter.send(SseEmitter.event().name("completed").data(Map.of(
+                            "statusmessage", "Realtime read failed: " + e.getMessage(),
+                            "success", 0,
+                            "failed", 0,
+                            "error", true
+                    )));
+                    emitter.complete();
+                } catch (Exception ignored) {
+                    emitter.completeWithError(e);
+                }
             }
         });
 

--- a/hes/src/main/java/com/memmcol/hesTraining/services/MeterReadingService.java
+++ b/hes/src/main/java/com/memmcol/hesTraining/services/MeterReadingService.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Service
 @Slf4j
@@ -43,6 +44,14 @@ public class MeterReadingService {
     private final SessionManagerMultiVendor sessionManagerMultiVendor;
     private final DlmsReaderUtils dlmsReaderUtils;
     private final MeterRatioService ratioService;
+
+    // Fail-fast on a per-DLMS-call basis during user-facing realtime reads.
+    // Cold/legacy calls in this class still use 20s.
+    private static final int REALTIME_DLMS_TIMEOUT_MS = 8000;
+
+    // Scaler+unit (attribute 3) is static per (meterModel, classId, obisCode).
+    // Caching eliminates one DLMS round-trip per realtime call.
+    private final Map<String, Object> scalerUnitCache = new ConcurrentHashMap<>();
 
     /*TODO:
      *  1. Create instantaneous read
@@ -620,6 +629,20 @@ public class MeterReadingService {
             return List.of();
         }
 
+        try {
+            return readObisValuesBatchOnce(meterModel, meterSerial, obisList, mdMeter);
+        } catch (Exception firstAttempt) {
+            log.warn("Batched OBIS read attempt 1 failed for meter={}: {} — invalidating session and retrying",
+                    meterSerial, firstAttempt.getMessage());
+            sessionManagerMultiVendor.removeSession(meterSerial);
+            return readObisValuesBatchOnce(meterModel, meterSerial, obisList, mdMeter);
+        }
+    }
+
+    private List<Map<String, Object>> readObisValuesBatchOnce(String meterModel,
+                                                              String meterSerial,
+                                                              List<String> obisList,
+                                                              boolean mdMeter) throws Exception {
         GXDLMSClient client = sessionManagerMultiVendor.getOrCreateClient(meterSerial);
         if (client == null) {
             throw new IllegalStateException("No active session for meter: " + meterSerial);
@@ -630,7 +653,7 @@ public class MeterReadingService {
             parsedObis.add(parseObis(obis));
         }
 
-        readScalerUnitsBatch(client, meterSerial, parsedObis);
+        readScalerUnitsBatch(client, meterModel, meterSerial, parsedObis);
 
         List<Map.Entry<GXDLMSObject, Integer>> valueReads = parsedObis.stream()
                 .<Map.Entry<GXDLMSObject, Integer>>map(parsed -> new AbstractMap.SimpleEntry<>(parsed.object(), parsed.attributeIndex()))
@@ -692,7 +715,10 @@ public class MeterReadingService {
         return response;
     }
 
-    private void readScalerUnitsBatch(GXDLMSClient client, String meterSerial, List<ParsedObis> parsedObis) throws Exception {
+    private void readScalerUnitsBatch(GXDLMSClient client,
+                                      String meterModel,
+                                      String meterSerial,
+                                      List<ParsedObis> parsedObis) throws Exception {
         List<ParsedObis> scalerReads = parsedObis.stream()
                 .filter(parsed -> supportsScalerUnit(parsed.objectType()))
                 .toList();
@@ -700,30 +726,57 @@ public class MeterReadingService {
             return;
         }
 
-        List<Map.Entry<GXDLMSObject, Integer>> reads = scalerReads.stream()
+        // Split into cached vs uncached; apply cached values directly, only batch-read the rest.
+        List<ParsedObis> uncached = new ArrayList<>(scalerReads.size());
+        for (ParsedObis parsed : scalerReads) {
+            Object cached = scalerUnitCache.get(scalerUnitKey(meterModel, parsed));
+            if (cached == null) {
+                uncached.add(parsed);
+                continue;
+            }
+            try {
+                client.updateValue(parsed.object(), 3, cached);
+            } catch (Exception ex) {
+                log.warn("Failed to apply cached scaler/unit for meter={} obis={}: {}",
+                        meterSerial, parsed.obisCode(), ex.getMessage());
+                uncached.add(parsed);
+            }
+        }
+        if (uncached.isEmpty()) {
+            log.debug("Scaler/unit fully served from cache for meter={} count={}", meterSerial, scalerReads.size());
+            return;
+        }
+
+        List<Map.Entry<GXDLMSObject, Integer>> reads = uncached.stream()
                 .<Map.Entry<GXDLMSObject, Integer>>map(parsed -> new AbstractMap.SimpleEntry<>(parsed.object(), 3))
                 .toList();
         List<Object> scalerValues = readListValues(client, meterSerial, reads);
 
-        for (int i = 0; i < scalerReads.size(); i++) {
+        for (int i = 0; i < uncached.size(); i++) {
+            ParsedObis parsed = uncached.get(i);
             if (i >= scalerValues.size()) {
                 log.warn("Batched scaler/unit read returned no value for meter={} obis={}",
-                        meterSerial, scalerReads.get(i).obisCode());
+                        meterSerial, parsed.obisCode());
                 continue;
             }
             Object scalerValue = unwrapBatchValue(scalerValues.get(i));
             if (isDlmsFailure(scalerValue)) {
                 log.warn("Batched scaler/unit read failed for meter={} obis={}: {}",
-                        meterSerial, scalerReads.get(i).obisCode(), dlmsFailureMessage(scalerValue));
+                        meterSerial, parsed.obisCode(), dlmsFailureMessage(scalerValue));
                 continue;
             }
             try {
-                client.updateValue(scalerReads.get(i).object(), 3, scalerValue);
+                client.updateValue(parsed.object(), 3, scalerValue);
+                scalerUnitCache.put(scalerUnitKey(meterModel, parsed), scalerValue);
             } catch (Exception ex) {
                 log.warn("Failed to apply batched scaler/unit for meter={} obis={}: {}",
-                        meterSerial, scalerReads.get(i).obisCode(), ex.getMessage());
+                        meterSerial, parsed.obisCode(), ex.getMessage());
             }
         }
+    }
+
+    private String scalerUnitKey(String meterModel, ParsedObis parsed) {
+        return (meterModel == null ? "?" : meterModel) + "|" + parsed.classId() + "|" + parsed.obisCode();
     }
 
     @SuppressWarnings("unchecked")
@@ -731,23 +784,41 @@ public class MeterReadingService {
                                         String meterSerial,
                                         List<Map.Entry<GXDLMSObject, Integer>> reads) throws Exception {
         byte[][] requests = client.readList(reads);
-        GXReplyData reply = new GXReplyData();
-
-        byte[] response = txRxService.sendReceiveWithContext(meterSerial, requests[0], 20000);
-        if (sessionManagerMultiVendor.isAssociationLost(response)) {
-            sessionManagerMultiVendor.removeSession(meterSerial);
-            throw new AssociationLostException("Association lost during batched OBIS read");
+        if (requests == null || requests.length == 0) {
+            return List.of();
         }
 
-        client.getData(response, reply, null);
-        Object value = reply.getValue();
-        if (value instanceof List<?> list) {
-            return (List<Object>) list;
+        List<Object> accumulated = new ArrayList<>(reads.size());
+
+        for (byte[] request : requests) {
+            GXReplyData reply = new GXReplyData();
+            byte[] response = txRxService.sendReceiveWithContext(meterSerial, request, REALTIME_DLMS_TIMEOUT_MS);
+            if (sessionManagerMultiVendor.isAssociationLost(response)) {
+                sessionManagerMultiVendor.removeSession(meterSerial);
+                throw new AssociationLostException("Association lost during batched OBIS read");
+            }
+            client.getData(response, reply, null);
+
+            // Drain continuation frames when the APDU spans multiple HDLC frames.
+            while (reply.isMoreData()) {
+                byte[] cont = client.receiverReady(reply);
+                byte[] contResp = txRxService.sendReceiveWithContext(meterSerial, cont, REALTIME_DLMS_TIMEOUT_MS);
+                if (sessionManagerMultiVendor.isAssociationLost(contResp)) {
+                    sessionManagerMultiVendor.removeSession(meterSerial);
+                    throw new AssociationLostException("Association lost during batched OBIS read");
+                }
+                client.getData(contResp, reply, null);
+            }
+
+            Object value = reply.getValue();
+            if (value instanceof List<?> list) {
+                accumulated.addAll((List<Object>) list);
+            } else if (value != null) {
+                accumulated.add(value);
+            }
         }
-        if (reads.size() == 1) {
-            return List.of(value);
-        }
-        throw new IllegalStateException("Batched OBIS read response was not a value list.");
+
+        return accumulated;
     }
 
     private Object unwrapBatchValue(Object value) {


### PR DESCRIPTION
Why
Real-time OBIS reads were averaging ~75s for 1 meter × 11 OBIS, and would fail outright on the second attempt while the UI kept spinning. Tracing the path through RealtimeReadSseService → MeterReadingService showed four distinct problems compounding:

Every realtime call issued a full DLMS round-trip just for the scaler/unit attribute before reading any value. Scaler/unit is static per (meterModel, OBIS) so this was ~50% pure overhead on every request.
readListValues only sent the first PDU out of client.readList(reads) and discarded requests[1..n]. Whenever the batched APDU spanned more than one HDLC frame (typical at 10+ registers, exactly the case being reported), the trailing values were silently dropped, every missing slot was marked "No DLMS value returned," and — if the operator had fallback-to-single-obis enabled — we then paid the 20s-per-OBIS fallback cascade.
The cached GXDLMSClient was only invalidated on the narrow AssociationLostException path. Any other DLMS-level failure left a half-broken client in the session cache, causing the next request to fail at the wire layer until the session was force-removed.
The 20s per-call DLMS timeout was the only safety net — a healthy meter answers a batched read in 1–3s on 4G or 2–4s on GPRS, so 20s is far too generous and held the whole pipeline hostage on transient errors.
On a top-level exception inside streamRealtimeRead, the emitter went straight to completeWithError, which means the FE never receives a named completed event — it just sees the socket drop and has no terminal-state hook to flip its spinner off.
What changed
MeterReadingService.java

Added scalerUnitCache: ConcurrentHashMap<String, Object> keyed by meterModel|classId|obisCode. readScalerUnitsBatch now partitions parsed OBIS into cached vs uncached — cached entries are applied directly via client.updateValue(obj, 3, cachedValue) and skip the wire entirely. Cache is populated on every successful batched scaler read. This eliminates one full DLMS round-trip per realtime call after the first.
New REALTIME_DLMS_TIMEOUT_MS = 8000 constant used only by readListValues. Other call paths (cold AARQ, clock reads, write ops) keep their existing 20s — this is a surgical change only on the user-facing realtime hot path.
readListValues now loops over every chunk in requests[] and drains continuation frames via client.receiverReady(reply) until reply.isMoreData() is false. Values from each chunk's reply are concatenated into a single list. This fixes the multi-frame data-loss bug and removes the "Batched OBIS read response was not a value list" failure mode for larger batches.
readObisValuesBatch was split into a public retry wrapper and a private readObisValuesBatchOnce. On any exception during the first attempt, the session is invalidated via sessionManagerMultiVendor.removeSession(meterSerial) and one fresh AARQ retry runs. Worst-case adds ~8s to a hard failure; eliminates the chronic "second attempt fails" pattern.
RealtimeReadSseService.java

Outer catch in streamRealtimeRead now best-effort sends a final completed SSE event (with error: true and the message) before falling back to completeWithError. Guarantees the FE always sees a terminal named event.