### PR TITLE
feat: Introduce InvalidObisFormatException for better OBIS error handling and adjust OBIS read limits in application properties

### DIFF
--- a/hes/src/main/java/com/memmcol/hes/exception/InvalidObisFormatException.java
+++ b/hes/src/main/java/com/memmcol/hes/exception/InvalidObisFormatException.java
@@ -1,0 +1,18 @@
+package com.memmcol.hes.exception;
+
+// Thrown when an OBIS request string is malformed (bad delimiters, non-numeric
+// parts, or an OBIS code that is not exactly six dot-separated bytes). Extends
+// IllegalArgumentException so it maps to 400 via GlobalExceptionHandler if it
+// ever escapes a tolerant batch loop.
+public class InvalidObisFormatException extends IllegalArgumentException {
+    private final String rawObis;
+
+    public InvalidObisFormatException(String rawObis, String message) {
+        super(message);
+        this.rawObis = rawObis;
+    }
+
+    public String getRawObis() {
+        return rawObis;
+    }
+}

--- a/hes/src/main/java/com/memmcol/hes/gridflex/services/RealtimeReadSseService.java
+++ b/hes/src/main/java/com/memmcol/hes/gridflex/services/RealtimeReadSseService.java
@@ -6,6 +6,7 @@ import com.memmcol.hes.gridflex.dtos.ObisDto;
 import com.memmcol.hes.gridflex.dtos.RealtimeReadRequest;
 import com.memmcol.hes.repository.MeterRepository;
 import com.memmcol.hesTraining.services.MeterReadingService;
+import gurux.dlms.GXDLMSExceptionResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -272,7 +273,12 @@ public class RealtimeReadSseService {
         } catch (Exception batchException) {
             log.warn("⚠️ Batched realtime read failed for meter={}: {}",
                     meter.getMeterSerial(), batchException.getMessage());
-            if (!fallbackToSingleObis) {
+            // Only fall back to per-OBIS reads when the meter rejected the entire
+            // GET-with-list at the DLMS layer. Other failures (network, association,
+            // formatting) won't be cured by N more reads on the same meter, so emit
+            // -1 immediately and let the user retry.
+            boolean wholeListRejection = isWholeListRejection(batchException);
+            if (!fallbackToSingleObis || !wholeListRejection) {
                 String message = "Batched realtime read failed: " + batchException.getMessage();
                 for (ObisDto obis : obisList) {
                     if (Thread.currentThread().isInterrupted() || !acceptingEvents.get()) {
@@ -323,6 +329,18 @@ public class RealtimeReadSseService {
         log.info("✅ Realtime read meter={} finished success={} failed={} elapsedMs={}",
                 meter.getMeterSerial(), success, failed, elapsedMs);
         return new RealtimeReadSummary(success, failed);
+    }
+
+    private boolean isWholeListRejection(Throwable ex) {
+        for (Throwable t = ex; t != null; t = t.getCause()) {
+            if (t instanceof GXDLMSExceptionResponse) {
+                return true;
+            }
+            if (t == t.getCause()) {
+                break;
+            }
+        }
+        return false;
     }
 
     private List<Map<String, Object>> readMeterObisValuesBatch(MeterDto meter,

--- a/hes/src/main/java/com/memmcol/hesTraining/services/MeterReadingService.java
+++ b/hes/src/main/java/com/memmcol/hesTraining/services/MeterReadingService.java
@@ -6,6 +6,7 @@ import com.memmcol.hes.infrastructure.dlms.DlmsDataDecoder;
 import com.memmcol.hes.infrastructure.dlms.DlmsReaderUtils;
 import com.memmcol.hes.nettyUtils.SessionManagerMultiVendor;
 import com.memmcol.hes.exception.AssociationLostException;
+import com.memmcol.hes.exception.InvalidObisFormatException;
 import com.memmcol.hes.service.MeterRatioService;
 import gurux.dlms.*;
 import gurux.dlms.enums.Authentication;
@@ -648,71 +649,91 @@ public class MeterReadingService {
             throw new IllegalStateException("No active session for meter: " + meterSerial);
         }
 
-        List<ParsedObis> parsedObis = new ArrayList<>(obisList.size());
-        for (String obis : obisList) {
-            parsedObis.add(parseObis(obis));
-        }
+        // Tolerant parse: bad OBIS strings are isolated from the batch instead of
+        // poisoning the whole call. Each request slot keeps its position so the
+        // returned list aligns 1:1 with obisList.
+        Map<String, Object>[] response = new Map[obisList.size()];
+        List<ParsedObis> goodParsed = new ArrayList<>(obisList.size());
+        List<Integer> goodIndexes = new ArrayList<>(obisList.size());
 
-        readScalerUnitsBatch(client, meterModel, meterSerial, parsedObis);
-
-        List<Map.Entry<GXDLMSObject, Integer>> valueReads = parsedObis.stream()
-                .<Map.Entry<GXDLMSObject, Integer>>map(parsed -> new AbstractMap.SimpleEntry<>(parsed.object(), parsed.attributeIndex()))
-                .toList();
-
-        List<Object> values = readListValues(client, meterSerial, valueReads);
-        MeterRatios meterRatios = mdMeter ? ratioService.readMeterRatios(meterModel, meterSerial) : null;
-        DecimalFormat formatter = new DecimalFormat("#,##0.00");
-        List<Map<String, Object>> response = new ArrayList<>(parsedObis.size());
-
-        for (int i = 0; i < parsedObis.size(); i++) {
-            ParsedObis parsed = parsedObis.get(i);
-            Map<String, Object> item = new LinkedHashMap<>();
-            item.put("Meter No", meterSerial);
-            item.put("obisCode", parsed.obisCode());
-            item.put("attributeIndex", parsed.attributeIndex());
-            item.put("dataIndex", parsed.dataIndex());
-            if (parsed.object() instanceof GXDLMSRegister register) {
-                item.put("scaler", register.getScaler() == 0 ? 1.0 : register.getScaler());
-                item.put("unit", getUnitSymbol(register.getUnit()));
-            } else if (parsed.object() instanceof GXDLMSExtendedRegister register) {
-                item.put("scaler", register.getScaler() == 0 ? 1.0 : register.getScaler());
-                item.put("unit", getUnitSymbol(register.getUnit()));
-            } else if (parsed.object() instanceof GXDLMSDemandRegister register) {
-                item.put("scaler", register.getScaler() == 0 ? 1.0 : register.getScaler());
-                item.put("unit", getUnitSymbol(register.getUnit()));
-            }
-
-            if (i >= values.size()) {
-                item.put("statuscode", -1);
-                item.put("error", "No DLMS value returned for this OBIS in batched response");
-                item.put("Actual Value", null);
-                response.add(item);
-                continue;
-            }
-
-            Object rawValue = unwrapBatchValue(values.get(i));
-            if (isDlmsFailure(rawValue)) {
-                item.put("statuscode", -1);
-                item.put("error", dlmsFailureMessage(rawValue));
-                item.put("Actual Value", null);
-                response.add(item);
-                continue;
-            }
-
+        for (int i = 0; i < obisList.size(); i++) {
+            String raw = obisList.get(i);
             try {
-                Object formattedValue = formatBatchValue(parsed, rawValue, mdMeter, meterRatios, formatter);
-                item.put("statuscode", 0);
-                item.put(mdMeter ? "Raw Value" : "value", rawValue);
-                item.put("Actual Value", formattedValue);
-            } catch (Exception ex) {
+                goodParsed.add(parseObis(raw));
+                goodIndexes.add(i);
+            } catch (InvalidObisFormatException ex) {
+                Map<String, Object> item = new LinkedHashMap<>();
+                item.put("Meter No", meterSerial);
+                item.put("obisCode", ex.getRawObis());
                 item.put("statuscode", -1);
-                item.put("error", "Failed to format batched OBIS value: " + ex.getMessage());
+                item.put("error", "Invalid OBIS format: " + ex.getMessage());
                 item.put("Actual Value", null);
+                response[i] = item;
             }
-            response.add(item);
         }
 
-        return response;
+        if (!goodParsed.isEmpty()) {
+            readScalerUnitsBatch(client, meterModel, meterSerial, goodParsed);
+
+            List<Map.Entry<GXDLMSObject, Integer>> valueReads = goodParsed.stream()
+                    .<Map.Entry<GXDLMSObject, Integer>>map(parsed -> new AbstractMap.SimpleEntry<>(parsed.object(), parsed.attributeIndex()))
+                    .toList();
+
+            List<Object> values = readListValues(client, meterSerial, valueReads);
+            MeterRatios meterRatios = mdMeter ? ratioService.readMeterRatios(meterModel, meterSerial) : null;
+            DecimalFormat formatter = new DecimalFormat("#,##0.00");
+
+            for (int g = 0; g < goodParsed.size(); g++) {
+                ParsedObis parsed = goodParsed.get(g);
+                int requestIdx = goodIndexes.get(g);
+                Map<String, Object> item = new LinkedHashMap<>();
+                item.put("Meter No", meterSerial);
+                item.put("obisCode", parsed.obisCode());
+                item.put("attributeIndex", parsed.attributeIndex());
+                item.put("dataIndex", parsed.dataIndex());
+                if (parsed.object() instanceof GXDLMSRegister register) {
+                    item.put("scaler", register.getScaler() == 0 ? 1.0 : register.getScaler());
+                    item.put("unit", getUnitSymbol(register.getUnit()));
+                } else if (parsed.object() instanceof GXDLMSExtendedRegister register) {
+                    item.put("scaler", register.getScaler() == 0 ? 1.0 : register.getScaler());
+                    item.put("unit", getUnitSymbol(register.getUnit()));
+                } else if (parsed.object() instanceof GXDLMSDemandRegister register) {
+                    item.put("scaler", register.getScaler() == 0 ? 1.0 : register.getScaler());
+                    item.put("unit", getUnitSymbol(register.getUnit()));
+                }
+
+                if (g >= values.size()) {
+                    item.put("statuscode", -1);
+                    item.put("error", "No DLMS value returned for this OBIS in batched response");
+                    item.put("Actual Value", null);
+                    response[requestIdx] = item;
+                    continue;
+                }
+
+                Object rawValue = unwrapBatchValue(values.get(g));
+                if (isDlmsFailure(rawValue)) {
+                    item.put("statuscode", -1);
+                    item.put("error", dlmsFailureMessage(rawValue));
+                    item.put("Actual Value", null);
+                    response[requestIdx] = item;
+                    continue;
+                }
+
+                try {
+                    Object formattedValue = formatBatchValue(parsed, rawValue, mdMeter, meterRatios, formatter);
+                    item.put("statuscode", 0);
+                    item.put(mdMeter ? "Raw Value" : "value", rawValue);
+                    item.put("Actual Value", formattedValue);
+                } catch (Exception ex) {
+                    item.put("statuscode", -1);
+                    item.put("error", "Failed to format batched OBIS value: " + ex.getMessage());
+                    item.put("Actual Value", null);
+                }
+                response[requestIdx] = item;
+            }
+        }
+
+        return Arrays.asList(response);
     }
 
     private void readScalerUnitsBatch(GXDLMSClient client,
@@ -865,16 +886,36 @@ public class MeterReadingService {
         return "DLMS access error";
     }
 
+    // OBIS code per COSEM spec: exactly six dot-separated unsigned bytes (a.b.c.d.e.f, each 0-255).
+    private static final java.util.regex.Pattern OBIS_CODE_PATTERN =
+            java.util.regex.Pattern.compile("^\\d+(\\.\\d+){5}$");
+
     private ParsedObis parseObis(String obis) {
+        if (obis == null) {
+            throw new InvalidObisFormatException("", "OBIS request is null");
+        }
         String[] parts = obis.split(";");
         if (parts.length != 4) {
-            throw new IllegalArgumentException("OBIS format must be: classId;obisCode;attributeIndex;dataIndex");
+            throw new InvalidObisFormatException(obis,
+                    "OBIS format must be: classId;obisCode;attributeIndex;dataIndex");
         }
 
-        int classId = Integer.parseInt(parts[0]);
+        int classId;
+        int attributeIndex;
+        int dataIndex;
+        try {
+            classId = Integer.parseInt(parts[0].trim());
+            attributeIndex = Integer.parseInt(parts[2].trim());
+            dataIndex = Integer.parseInt(parts[3].trim());
+        } catch (NumberFormatException ex) {
+            throw new InvalidObisFormatException(obis,
+                    "OBIS classId/attributeIndex/dataIndex must be integers");
+        }
         String obisCode = parts[1].trim();
-        int attributeIndex = Integer.parseInt(parts[2]);
-        int dataIndex = Integer.parseInt(parts[3]);
+        if (!OBIS_CODE_PATTERN.matcher(obisCode).matches()) {
+            throw new InvalidObisFormatException(obis,
+                    "OBIS code must be six dot-separated bytes (a.b.c.d.e.f), got: " + obisCode);
+        }
         ObjectType objectType = ObjectType.forValue(classId);
         GXDLMSObject object = createObject(objectType, obisCode);
         return new ParsedObis(obis, obisCode, classId, attributeIndex, dataIndex, objectType, object);

--- a/hes/src/main/resources/application.properties
+++ b/hes/src/main/resources/application.properties
@@ -38,8 +38,8 @@ hes.quartz.cron.time-zone=Africa/Lagos
 hes.profile.household.models=MMX-110-NG,MMX-310-NG
 
 # Realtime multi-meter OBIS reads are user-facing, so keep them bounded.
-hes.realtime-read.max-meters=50
-hes.realtime-read.max-obis=20
+hes.realtime-read.max-meters=20
+hes.realtime-read.max-obis=50
 hes.realtime-read.timeout-seconds=120
 hes.realtime-read.stream-executor.size=10
 hes.realtime-read.fallback-md-model=MDModelX


### PR DESCRIPTION
Summary
Lower hes.realtime-read.max-meters from 50 → 20 and raise hes.realtime-read.max-obis from 20 → 50 to match the desired UX (max 20 meters per request, up to 50 OBIS shared across them).
Make readObisValuesBatchOnce tolerant: one bad OBIS in the request no longer poisons the whole batch. Malformed OBIS get an immediate -1 placeholder with a clear "Invalid OBIS format" message; valid OBIS still go through the batched DLMS GET-with-list in a single round trip.
Add InvalidObisFormatException (extends IllegalArgumentException) and regex validation in parseObis() to enforce the COSEM 6-byte OBIS format (a.b.c.d.e.f) plus integer validation on classId/attributeIndex/dataIndex.
Narrow the SSE service fallback path: single-OBIS fallback now triggers only when the meter rejects the entire GET-with-list at the DLMS layer (GXDLMSExceptionResponse in the cause chain). All other batch failures emit -1 immediately instead of walking N sequential reads.
Why
A live trace of a 1-meter × 12-OBIS read took 30-40s and returned 5 success / 7 failed — none had batch: true in the payload, meaning every OBIS went through the slow single-read fallback. Root cause: a handful of malformed/unsupported OBIS codes in the catalog (0-0:97.97.1.255, 0.0.1.0.0.255.255, manufacturer-specific codes the meter doesn't expose) made parseObis() or Gurux throw, which killed the whole batch attempt, triggered a session-reset retry that also threw, and finally fell through to 12 sequential single reads.

With tolerant batching, the same read should complete in ~3-5s: the bad OBIS fail fast with a clear error, the good OBIS come back in one DLMS round trip.

The limit swap (max-meters 50→20, max-obis 20→50) reflects the actual operational ask: cap concurrent meter fan-out (each meter consumes a thread and a session) while letting users pull a richer OBIS set per meter.

Files
application.properties — limit values
RealtimeReadSseService.java — narrowed fallback + isWholeListRejection helper
MeterReadingService.java — tolerant batch loop + stricter parseObis()
InvalidObisFormatException.java (new)