### PR TITLE
feat: Enable fallback to single OBIS reads in application properties and enhance handling in RealtimeReadSseService

### DIFF
--- a/hes/src/main/java/com/memmcol/hes/gridflex/services/RealtimeReadSseService.java
+++ b/hes/src/main/java/com/memmcol/hes/gridflex/services/RealtimeReadSseService.java
@@ -260,6 +260,29 @@ public class RealtimeReadSseService {
             int to = Math.min(from + obisChunkSize, obisList.size());
             List<ObisDto> chunk = obisList.subList(from, to);
 
+            if (chunk.size() == 1) {
+                ObisDto obis = chunk.getFirst();
+                Map<String, Object> reading = readSingleObis(meter, obis);
+                reading.put("chunkSize", chunk.size());
+
+                if (Integer.valueOf(0).equals(reading.get("statuscode"))) {
+                    success++;
+                    totalSuccess.incrementAndGet();
+                } else {
+                    failed++;
+                    totalFailed.incrementAndGet();
+                }
+
+                if (acceptingEvents.get()) {
+                    send(emitter, "reading", reading);
+                }
+
+                log.info("✅ Realtime read meter={} single-obis={}/{} elapsedMs={}",
+                        meter.getMeterSerial(), to, obisList.size(),
+                        TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - meterStarted));
+                continue;
+            }
+
             try {
                 List<Map<String, Object>> batchReadings = readMeterObisValuesBatch(meter, chunk, meterStarted);
                 for (Map<String, Object> reading : batchReadings) {
@@ -343,6 +366,11 @@ public class RealtimeReadSseService {
     private boolean isWholeListRejection(Throwable ex) {
         for (Throwable t = ex; t != null; t = t.getCause()) {
             if (t instanceof GXDLMSExceptionResponse) {
+                return true;
+            }
+            String message = t.getMessage();
+            if (message != null &&
+                    message.toLowerCase().contains("support multiple objects reading")) {
                 return true;
             }
             if (t == t.getCause()) {

--- a/hes/src/main/resources/application.properties
+++ b/hes/src/main/resources/application.properties
@@ -45,7 +45,7 @@ hes.realtime-read.stream-executor.size=10
 hes.realtime-read.obis-chunk-size=1
 hes.realtime-read.fallback-md-model=MDModelX
 hes.realtime-read.fallback-non-md-model=NonMDModelX
-hes.realtime-read.fallback-to-single-obis=false
+hes.realtime-read.fallback-to-single-obis=true
 
 #============================================================================
 # Job Interval Configuration


### PR DESCRIPTION
Improved realtime HES reads so OBIS values are streamed progressively to the UI and meters that do not support DLMS multiple-object reads are handled safely.

What Changed
Updated realtime HES reads to support configurable OBIS chunking.
Set default realtime OBIS chunk size to 1.
Routed single-OBIS chunks through the existing single-read path instead of the batched DLMS multi-object path.
Enabled fallback from batched reads to single-OBIS reads.
Added detection for meters that reject multiple-object reads with errors like:
Meter doesnt support multiple objects reading with one request
Updated the GridFlex backend stream proxy to split OBIS requests into smaller chunks before calling HES.
Fixed GridFlex backend permission matching for the actual HES stream endpoints.
Updated the frontend realtime table so rows remain visible while streaming and cells update as each OBIS result arrives.
Increased frontend realtime timeout to avoid aborting valid long-running meter reads.
Why
Some meters do not support reading multiple OBIS objects in a single DLMS request. The previous realtime flow could wait for a full batch to finish, or fail entirely when the meter rejected multiple-object reads.

This change makes realtime reads more reliable and user-friendly by reading OBIS values progressively and streaming each result to the UI as soon as it is available.