### PR TITLE
feat: Enhance MeterHeartbeatService and MeterHeartbeatManager to handle event timestamps and improve channel management in MeterConnections

### DIFF
--- a/hes/src/main/java/com/memmcol/hes/gridflex/sse/MeterHeartbeatService.java
+++ b/hes/src/main/java/com/memmcol/hes/gridflex/sse/MeterHeartbeatService.java
@@ -24,17 +24,14 @@ public class MeterHeartbeatService {
 
         log.debug("Push message from meter {}, status: {}", meterNo, status);
 
-        MeterStatusEvent event = new MeterStatusEvent(
-                meterNo,
-                ZonedDateTime.now(ZoneId.systemDefault()).toLocalDateTime(),
-                status
-        );
+        LocalDateTime eventTime = ZonedDateTime.now(ZoneId.systemDefault()).toLocalDateTime();
+        MeterStatusEvent event = new MeterStatusEvent(meterNo, eventTime, status);
 
         // 1️⃣ Publish to SSE clients
         publisher.publish(event);
 
         // 2️⃣ Push into DB buffer (asynchronously flushed)
-        heartbeatManager.handleStatus(meterNo, status);
+        heartbeatManager.handleStatus(meterNo, status, eventTime);
 
         log.debug("Processed login/heartbeat frame for meter {}, status: {}", meterNo, status);
     }

--- a/hes/src/main/java/com/memmcol/hes/netty/DLMSMeterHandler.java
+++ b/hes/src/main/java/com/memmcol/hes/netty/DLMSMeterHandler.java
@@ -42,11 +42,17 @@ public class DLMSMeterHandler extends SimpleChannelInboundHandler<byte[]> {
 
     @Override
     public void channelInactive(ChannelHandlerContext ctx) {
-//        meterStatusService.broadcastMeterOffline(MeterConnections.getSerial(ctx.channel()));
-//        heartbeatManager.handleStatus(MeterConnections.getSerial(ctx.channel()), "OFFLINE");
         String serial = MeterConnections.getSerial(ctx.channel());
         if (serial != null) {
-            heartbeatService.processFrame(serial, "OFFLINE");
+            // Only report OFFLINE if this channel is still the meter's active
+            // connection. A stale channel disconnecting after the meter has
+            // reconnected on a new socket must not flip a live meter to OFFLINE.
+            if (MeterConnections.isCurrentChannel(serial, ctx.channel())) {
+                heartbeatService.processFrame(serial, "OFFLINE");
+            } else {
+                log.info("ℹ️ Stale channel {} for meter {} disconnected; meter is live on a newer connection — skipping OFFLINE",
+                        ctx.channel().remoteAddress(), serial);
+            }
         } else {
             log.info("❌ Disconnected unknown channel (no meter serial bound) {}", ctx.channel().remoteAddress());
         }

--- a/hes/src/main/java/com/memmcol/hes/nettyUtils/MeterHeartbeatManager.java
+++ b/hes/src/main/java/com/memmcol/hes/nettyUtils/MeterHeartbeatManager.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.*;
 import java.util.concurrent.*;
 
@@ -59,9 +60,12 @@ public class MeterHeartbeatManager {
     }
 
     /**
-     * Called on every heartbeat / login / disconnect
+     * Called on every heartbeat / login / disconnect.
+     *
+     * @param eventTime the time the status event was produced (not the time it
+     *                  is processed) — used to reject out-of-order updates.
      */
-    public void handleStatus(String meterId, String status) {
+    public void handleStatus(String meterId, String status, LocalDateTime eventTime) {
 
         // Netty can call disconnect handlers before a meter has bound its serial.
         // ConcurrentHashMap does not allow null keys/values, so guard aggressively here.
@@ -70,22 +74,35 @@ public class MeterHeartbeatManager {
             return;
         }
         final String safeStatus = (status == null) ? "UNKNOWN" : status;
+        final LocalDateTime safeTime = (eventTime == null) ? LocalDateTime.now() : eventTime;
+        final long eventEpoch = safeTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
 
-        long now = System.currentTimeMillis();
-        LocalDateTime time = LocalDateTime.now();
-
-        // 🔥 ALWAYS update buffer (latest wins)
-        writeBuffer.put(meterId, new MeterUpdateDTO(meterId, safeStatus, time));
-
-        // Update in-memory state
+        // Apply the update only if it is at least as recent as the last one we
+        // processed for this meter. A late-arriving (e.g. stale-channel) OFFLINE
+        // must not clobber a newer ONLINE.
+        boolean[] applied = {false};
         stateMap.compute(meterId, (k, state) -> {
             if (state == null) {
-                return new MeterState(safeStatus, now);
+                applied[0] = true;
+                return new MeterState(safeStatus, eventEpoch);
+            }
+            if (eventEpoch < state.lastSeenEpoch) {
+                log.debug("⏮️ Ignoring out-of-order status for meter {} (event={}, last seen newer)",
+                        meterId, safeStatus);
+                return state;
             }
             state.status = safeStatus;
-            state.lastSeenEpoch = now;
+            state.lastSeenEpoch = eventEpoch;
+            applied[0] = true;
             return state;
         });
+
+        if (!applied[0]) {
+            return;
+        }
+
+        // Buffer the DB write (latest applied state wins)
+        writeBuffer.put(meterId, new MeterUpdateDTO(meterId, safeStatus, safeTime));
 
         // Early flush under pressure
         if (writeBuffer.size() >= BUFFER_FLUSH_THRESHOLD) {

--- a/hes/src/main/java/com/memmcol/hes/service/MeterConnections.java
+++ b/hes/src/main/java/com/memmcol/hes/service/MeterConnections.java
@@ -19,13 +19,21 @@ public final class MeterConnections {
     private MeterConnections() {}
 
     public static void bind(Channel channel, String serial) {
+        Channel previous = SERIAL_TO_CHANNEL_meterConnectionsPool.put(serial, channel);
         CHANNEL_TO_SERIAL_meterConnectionsPool.put(channel, serial);
-        SERIAL_TO_CHANNEL_meterConnectionsPool.put(serial, channel);
         CHANNEL_INBOUND_QUEUES.put(channel, new ConcurrentLinkedQueue<>());
         log.debug("🔗 Binding channel {} to serial {}", channel.id(), serial);
 
-        log.debug("🔍 Looking for serial '{}'", serial);
-        log.debug("🔍 Current serials: {}", SERIAL_TO_CHANNEL_meterConnectionsPool.keySet());
+        // A meter re-connected on a new socket before the old one was torn down.
+        // Drop the stale channel so its later disconnect cannot emit a phantom
+        // OFFLINE for this meter, which is now live on the new channel.
+        if (previous != null && previous != channel) {
+            CHANNEL_TO_SERIAL_meterConnectionsPool.remove(previous);
+            CHANNEL_INBOUND_QUEUES.remove(previous);
+            previous.close();
+            log.info("🔁 Serial {} rebound to channel {}; closed stale channel {}",
+                    serial, channel.id(), previous.id());
+        }
     }
 
     public static String getSerial(Channel channel) {
@@ -52,10 +60,23 @@ public final class MeterConnections {
 
     public static void remove(Channel channel) {
         String serial = CHANNEL_TO_SERIAL_meterConnectionsPool.remove(channel);
-        if (serial != null) SERIAL_TO_CHANNEL_meterConnectionsPool.remove(serial);
+        if (serial != null) {
+            // Only clear the serial mapping if it still points to THIS channel.
+            // If the meter already reconnected on a newer channel, keep that intact.
+            SERIAL_TO_CHANNEL_meterConnectionsPool.remove(serial, channel);
+        }
         CHANNEL_INBOUND_QUEUES.remove(channel);
         channel.close();
         log.info("❌ Disconnected Meter and connection {}", serial);
+    }
+
+    /**
+     * True only if {@code serial} is currently bound to exactly {@code channel}.
+     * Used to suppress OFFLINE events from stale channels after a reconnect.
+     */
+    public static boolean isCurrentChannel(String serial, Channel channel) {
+        return serial != null && channel != null
+                && SERIAL_TO_CHANNEL_meterConnectionsPool.get(serial) == channel;
     }
 
     public static boolean isActive(String serial) {


### PR DESCRIPTION
WHY
Meters were rapidly flipping between online and offline (multiple times per second) on the communication report. Root cause: when a meter reconnected on a new TCP socket before the old one was torn down, the leftover stale channel's channelInactive emitted a phantom OFFLINE for a meter that was actually live on the new connection — and MeterConnections.remove() unconditionally unmapped the live channel.

Changes:

MeterConnections.bind() now evicts and closes the previous channel when a serial is rebound; remove() only clears the serial mapping if it still points to that exact channel; added isCurrentChannel().
DLMSMeterHandler.channelInactive() only emits OFFLINE when the disconnecting channel is still the meter's current connection.
MeterHeartbeatManager.handleStatus() now takes an event timestamp and rejects out-of-order updates, so a late OFFLINE can't overwrite a newer ONLINE (defense in depth).
Result: reconnecting meters no longer generate phantom OFFLINE events; status on the report stays stable and correct.