### PR TITLE
feat: Improve meter offline handling by enforcing communication-timeout rules and marking stale ONLINE meters OFFLINE

### DIFF
--- a/hes/src/main/java/com/memmcol/hes/netty/DLMSMeterHandler.java
+++ b/hes/src/main/java/com/memmcol/hes/netty/DLMSMeterHandler.java
@@ -44,15 +44,10 @@ public class DLMSMeterHandler extends SimpleChannelInboundHandler<byte[]> {
     public void channelInactive(ChannelHandlerContext ctx) {
         String serial = MeterConnections.getSerial(ctx.channel());
         if (serial != null) {
-            // Only report OFFLINE if this channel is still the meter's active
-            // connection. A stale channel disconnecting after the meter has
-            // reconnected on a new socket must not flip a live meter to OFFLINE.
-            if (MeterConnections.isCurrentChannel(serial, ctx.channel())) {
-                heartbeatService.processFrame(serial, "OFFLINE");
-            } else {
-                log.info("ℹ️ Stale channel {} for meter {} disconnected; meter is live on a newer connection — skipping OFFLINE",
-                        ctx.channel().remoteAddress(), serial);
-            }
+            // Socket lifecycle is transport-level. Meter OFFLINE is decided by
+            // heartbeat/communication timeout, not by an individual TCP close.
+            log.info("ℹ️ Channel {} for meter {} disconnected; offline status will be decided by communication timeout",
+                    ctx.channel().remoteAddress(), serial);
         } else {
             log.info("❌ Disconnected unknown channel (no meter serial bound) {}", ctx.channel().remoteAddress());
         }
@@ -90,6 +85,7 @@ public class DLMSMeterHandler extends SimpleChannelInboundHandler<byte[]> {
 
         if (apduTag == (byte) 0xC2) {
             log.info("📩 Event Notification received from meter {}: {}", serial, formatHex(msg));
+            markMeterCommunication(serial);
 
             dlmsScheduledExecutor.submit(() -> {
                 try {
@@ -124,6 +120,7 @@ public class DLMSMeterHandler extends SimpleChannelInboundHandler<byte[]> {
 
         // --- Step 4: Light RX logging ---
         if (serial != null) {
+            markMeterCommunication(serial);
             log.info("RX: {} : {}", serial, formatHex(msg));
             logRx(serial, msg);
         } else {
@@ -307,6 +304,12 @@ public class DLMSMeterHandler extends SimpleChannelInboundHandler<byte[]> {
             handler.process(serial, data);  // call your new class
         } catch (Exception e) {
             log.error("❌ Error handling EventNotification for {}: {}", serial, e.getMessage(), e);
+        }
+    }
+
+    private void markMeterCommunication(String serial) {
+        if (serial != null && !serial.isBlank()) {
+            heartbeatService.processFrame(serial, "ONLINE");
         }
     }
 

--- a/hes/src/main/java/com/memmcol/hes/nettyUtils/MeterHeartbeatManager.java
+++ b/hes/src/main/java/com/memmcol/hes/nettyUtils/MeterHeartbeatManager.java
@@ -117,14 +117,21 @@ public class MeterHeartbeatManager {
 
         long now = System.currentTimeMillis();
         long thresholdMillis = TimeUnit.MINUTES.toMillis(OFFLINE_THRESHOLD_MINUTES);
+        LocalDateTime offlineTime = LocalDateTime.now();
+        Set<String> recentlySeenMeters = new HashSet<>();
 
         for (Map.Entry<String, MeterState> entry : stateMap.entrySet()) {
 
             String meterId = entry.getKey();
             MeterState state = entry.getValue();
+            long millisSinceLastSeen = now - state.lastSeenEpoch;
+
+            if (millisSinceLastSeen <= thresholdMillis) {
+                recentlySeenMeters.add(meterId);
+            }
 
             if ("ONLINE".equals(state.status) &&
-                    (now - state.lastSeenEpoch) > thresholdMillis) {
+                    millisSinceLastSeen > thresholdMillis) {
 
                 log.info("🔻 Meter {} marked OFFLINE (timeout)", meterId);
 
@@ -133,9 +140,19 @@ public class MeterHeartbeatManager {
                 // Buffer OFFLINE update (same pipeline)
                 writeBuffer.put(
                         meterId,
-                        new MeterUpdateDTO(meterId, "OFFLINE", LocalDateTime.now())
+                        new MeterUpdateDTO(meterId, "OFFLINE", offlineTime)
                 );
             }
+        }
+
+        try {
+            LocalDateTime staleBefore = offlineTime.minusMinutes(OFFLINE_THRESHOLD_MINUTES);
+            int staleRows = batchRepository.markStaleOnlineMetersOffline(staleBefore, offlineTime, recentlySeenMeters);
+            if (staleRows > 0) {
+                log.info("🔻 Marked {} stale ONLINE meter rows OFFLINE (timeout)", staleRows);
+            }
+        } catch (Exception e) {
+            log.error("❌ Failed to mark stale ONLINE meter rows OFFLINE", e);
         }
     }
 

--- a/hes/src/main/java/com/memmcol/hes/repository/MetersConnectionEventBatchRepository.java
+++ b/hes/src/main/java/com/memmcol/hes/repository/MetersConnectionEventBatchRepository.java
@@ -5,6 +5,9 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 @Repository
@@ -72,5 +75,38 @@ public class MetersConnectionEventBatchRepository {
             ps.setTimestamp(4, ts);
             ps.setTimestamp(5, ts);
         });
+    }
+
+    /**
+     * Enforce the communication-timeout rule from persisted state too. This
+     * prevents old ONLINE rows surviving indefinitely after an application restart.
+     */
+    public int markStaleOnlineMetersOffline(LocalDateTime staleBefore,
+                                            LocalDateTime offlineTime,
+                                            Collection<String> recentlySeenMeters) {
+        StringBuilder sql = new StringBuilder("""
+                UPDATE meters_connection_event
+                SET connection_type = 'OFFLINE',
+                    offline_time = ?,
+                    updated_at = ?
+                WHERE connection_type = 'ONLINE'
+                  AND COALESCE(updated_at, online_time) < ?
+                """);
+
+        Timestamp ts = Timestamp.valueOf(offlineTime);
+        List<Object> args = new ArrayList<>();
+        args.add(ts);
+        args.add(ts);
+        args.add(Timestamp.valueOf(staleBefore));
+
+        if (recentlySeenMeters != null && !recentlySeenMeters.isEmpty()) {
+            sql.append(" AND meter_no NOT IN (");
+            sql.append("?,".repeat(recentlySeenMeters.size()));
+            sql.setLength(sql.length() - 1);
+            sql.append(")");
+            args.addAll(recentlySeenMeters);
+        }
+
+        return jdbcTemplate.update(sql.toString(), args.toArray());
     }
 }


### PR DESCRIPTION
Previously, when a Netty channel became inactive, the backend immediately marked the meter as OFFLINE. This caused false offline transitions when meters were briefly disconnected, reconnected, or rotated sockets, especially over unstable cellular networks. A socket close does not necessarily mean the meter is offline; it only means that a specific transport session ended.

What changed:

Removed immediate OFFLINE status updates from channelInactive.
Treat channel inactivity as socket/session cleanup only.
Keep the existing 2-minute timeout as the source of truth for offline detection.
Refresh meter ONLINE status when valid communication is received, including login/heartbeat, event notifications, and normal DLMS responses.
Added database-level stale ONLINE cleanup so old online rows are marked OFFLINE after restart if they have not communicated within the timeout window.
Protected recently seen in-memory meters from being incorrectly marked offline before buffered writes flush to the database.
Why:

Aligns status behavior with the business rule: a meter is offline only when it has not communicated for 2 minutes.
Prevents false online/offline flapping caused by TCP socket churn.
Improves the accuracy of the communication report and dashboard meter status.
Makes status recovery safer after HES application restarts.