### PR TITLE
feat: Integrate MeterStatusSsePublisher to publish offline meter status events

### DIFF
--- a/hes/src/main/java/com/memmcol/hes/nettyUtils/MeterHeartbeatManager.java
+++ b/hes/src/main/java/com/memmcol/hes/nettyUtils/MeterHeartbeatManager.java
@@ -1,6 +1,8 @@
 package com.memmcol.hes.nettyUtils;
 
 import com.memmcol.hes.dto.MeterUpdateDTO;
+import com.memmcol.hes.gridflex.sse.MeterStatusEvent;
+import com.memmcol.hes.gridflex.sse.MeterStatusSsePublisher;
 import com.memmcol.hes.repository.MetersConnectionEventBatchRepository;
 import jakarta.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
@@ -40,9 +42,12 @@ public class MeterHeartbeatManager {
     );
 
     private final MetersConnectionEventBatchRepository batchRepository;
+    private final MeterStatusSsePublisher statusPublisher;
 
-    public MeterHeartbeatManager(MetersConnectionEventBatchRepository batchRepository) {
+    public MeterHeartbeatManager(MetersConnectionEventBatchRepository batchRepository,
+                                 MeterStatusSsePublisher statusPublisher) {
         this.batchRepository = batchRepository;
+        this.statusPublisher = statusPublisher;
 
         scheduler.scheduleAtFixedRate(
                 this::flushToDatabase,
@@ -142,6 +147,7 @@ public class MeterHeartbeatManager {
                         meterId,
                         new MeterUpdateDTO(meterId, "OFFLINE", offlineTime)
                 );
+                statusPublisher.publish(new MeterStatusEvent(meterId, offlineTime, "OFFLINE"));
             }
         }
 


### PR DESCRIPTION
This PR updates the meter-status SSE flow so timeout-driven offline transitions are published live to downstream consumers.

What Changed
Added meter-status SSE publishing when MeterHeartbeatManager marks a meter OFFLINE after the configured communication timeout.
Reused the existing MeterStatusSsePublisher and MeterStatusEvent flow so timeout-generated offline events use the same stream as other meter status updates.

Why
The HES offline business rule is now based on communication freshness: a meter becomes offline when it has not communicated within the timeout window. Before this change, timeout-driven offline status was written to persistence but was not emitted to SSE subscribers, so live clients could receive ONLINE activity but miss the corresponding timeout OFFLINE transition until they refreshed from the API/database.

This change keeps live consumers aligned with the backend status rule and allows UIs listening to the meter-status stream to update offline state immediately.