### PR TITLE
Fix Frozen Timestamps in Household Event Logs

### DIFF
--- a/hes/src/main/java/com/memmcol/hes/domain/profile/EventLogService.java
+++ b/hes/src/main/java/com/memmcol/hes/domain/profile/EventLogService.java
@@ -110,10 +110,12 @@ public class EventLogService {
                 }
 
                 if (rawRows == null || rawRows.isEmpty()) {
-                     log.warn("Empty profile response meter={} profile={} from={} to={}",
+                    log.warn("Empty profile response meter={} profile={} from={} to={}",
                             meterSerial, profileObis, from, to);
-                     cursor = new ProfileTimestamp(to);   // ALWAYS move forward deterministically
-                     continue;
+                    // ALWAYS move forward and persist for event log
+                    HouseholdDayWindowIngestionSupport.jumpAndPersistState(statePort, meterSerial, profileObis, to);
+                    cursor = new ProfileTimestamp(to);
+                    continue;
                 }
 
                 List<EventLogDTO> eventDtos = eventLogMapper.toDTOs(rawRows, meterSerial, model);
@@ -125,9 +127,13 @@ public class EventLogService {
                 // Persist new cursor — null-safe
                 ProfileTimestamp resume = ProfileTimestamp.ofNullable(syncResult.getAdvanceTo());
 
-                cursor = (resume != null)
-              ? resume
-              : new ProfileTimestamp(to);
+                if (resume == null || !resume.value().isAfter(from)) {
+                    log.info("Persistence did not advance cursor meter={} profile={} to={}", meterSerial, profileObis, to);
+                    HouseholdDayWindowIngestionSupport.jumpAndPersistState(statePort, meterSerial, profileObis, to);
+                    cursor = new ProfileTimestamp(to);
+                } else {
+                    cursor = resume;
+                }
 
                 if (cp.seconds() <= 0) {
                     log.warn("cp.seconds() <= 0 : {}", cp);

--- a/hes/src/main/java/com/memmcol/hes/domain/profile/HouseholdDayWindowIngestionSupport.java
+++ b/hes/src/main/java/com/memmcol/hes/domain/profile/HouseholdDayWindowIngestionSupport.java
@@ -11,6 +11,8 @@ import java.util.function.Predicate;
  * {@code meter_profile_state.last_timestamp} must only be updated from timestamps present on
  * meter profile rows (via persistence adapters). Use {@link #advanceInMemoryCursor} for gap
  * skipping within a single job run — never persist cursor or system time as {@code last_timestamp}.
+ * <p>
+ * For event-type profiles, this rule may be relaxed to "jump" gaps when no data is returned.
  */
 public final class HouseholdDayWindowIngestionSupport {
 
@@ -43,6 +45,16 @@ public final class HouseholdDayWindowIngestionSupport {
      */
     public static ProfileTimestamp nextCursorAfterBatch(ProfileSyncResult syncResult) {
         return ProfileTimestamp.ofNullable(syncResult.getAdvanceTo());
+    }
+
+    /**
+     * Jumps the persistence state to the end of the window. Use with caution for events only.
+     */
+    public static void jumpAndPersistState(ProfileStatePort statePort,
+                                           String meterSerial,
+                                           String profileObis,
+                                           LocalDateTime windowEnd) {
+        statePort.upsertState(meterSerial, profileObis, new ProfileTimestamp(windowEnd), new CapturePeriod(1));
     }
 
     /**

--- a/hes/src/main/java/com/memmcol/hes/domain/profile/HouseholdExtendedEventService.java
+++ b/hes/src/main/java/com/memmcol/hes/domain/profile/HouseholdExtendedEventService.java
@@ -113,6 +113,7 @@ public class HouseholdExtendedEventService {
                 if (rawRows == null || rawRows.isEmpty()) {
                     log.warn("Empty profile response meter={} profile={} from={} to={}",
                             meterSerial, profileObis, from, to);
+                    HouseholdDayWindowIngestionSupport.jumpAndPersistState(statePort, meterSerial, profileObis, to);
                     cursor = HouseholdDayWindowIngestionSupport.advanceInMemoryCursor(to);
                     continue;
                 }
@@ -121,6 +122,7 @@ public class HouseholdExtendedEventService {
                 if (syncResult == null) {
                     log.warn("Mapped event rows not persistable meter={} profile={} from={} to={} rawCount={}",
                             meterSerial, profileObis, from, to, rawRows.size());
+                    HouseholdDayWindowIngestionSupport.jumpAndPersistState(statePort, meterSerial, profileObis, to);
                     cursor = HouseholdDayWindowIngestionSupport.advanceInMemoryCursor(to);
                     continue;
                 }
@@ -129,11 +131,13 @@ public class HouseholdExtendedEventService {
                 metricsPort.recordBatch(meterSerial, profileObis, syncResult.getInsertedCount(), t1);
 
                 ProfileTimestamp resume = HouseholdDayWindowIngestionSupport.nextCursorAfterBatch(syncResult);
-                if (resume == null) {
-                    log.warn("No meter-derived advanceTo after persist meter={} profile={}", meterSerial, profileObis);
-                    break;
+                if (resume == null || !resume.value().isAfter(from)) {
+                    log.info("Persistence did not advance cursor meter={} profile={} to={}", meterSerial, profileObis, to);
+                    HouseholdDayWindowIngestionSupport.jumpAndPersistState(statePort, meterSerial, profileObis, to);
+                    cursor = HouseholdDayWindowIngestionSupport.advanceInMemoryCursor(to);
+                } else {
+                    cursor = resume;
                 }
-                cursor = resume;
 
                 if (cp.seconds() <= 0) {
                     log.warn("cp.seconds() <= 0 : {}", cp);

--- a/hes/src/main/java/com/memmcol/hes/domain/profile/HouseholdTokenEventService.java
+++ b/hes/src/main/java/com/memmcol/hes/domain/profile/HouseholdTokenEventService.java
@@ -113,6 +113,7 @@ public class HouseholdTokenEventService {
                 if (rawRows == null || rawRows.isEmpty()) {
                     log.warn("Empty profile response meter={} profile={} from={} to={}",
                             meterSerial, profileObis, from, to);
+                    HouseholdDayWindowIngestionSupport.jumpAndPersistState(statePort, meterSerial, profileObis, to);
                     cursor = HouseholdDayWindowIngestionSupport.advanceInMemoryCursor(to);
                     continue;
                 }
@@ -121,6 +122,7 @@ public class HouseholdTokenEventService {
                 if (syncResult == null) {
                     log.warn("Mapped token event rows not persistable meter={} profile={} from={} to={} rawCount={}",
                             meterSerial, profileObis, from, to, rawRows.size());
+                    HouseholdDayWindowIngestionSupport.jumpAndPersistState(statePort, meterSerial, profileObis, to);
                     cursor = HouseholdDayWindowIngestionSupport.advanceInMemoryCursor(to);
                     continue;
                 }
@@ -129,11 +131,13 @@ public class HouseholdTokenEventService {
                 metricsPort.recordBatch(meterSerial, profileObis, syncResult.getInsertedCount(), t1);
 
                 ProfileTimestamp resume = HouseholdDayWindowIngestionSupport.nextCursorAfterBatch(syncResult);
-                if (resume == null) {
-                    log.warn("No meter-derived advanceTo after persist meter={} profile={}", meterSerial, profileObis);
-                    break;
+                if (resume == null || !resume.value().isAfter(from)) {
+                    log.info("Persistence did not advance cursor meter={} profile={} to={}", meterSerial, profileObis, to);
+                    HouseholdDayWindowIngestionSupport.jumpAndPersistState(statePort, meterSerial, profileObis, to);
+                    cursor = HouseholdDayWindowIngestionSupport.advanceInMemoryCursor(to);
+                } else {
+                    cursor = resume;
                 }
-                cursor = resume;
 
                 if (cp.seconds() <= 0) {
                     log.warn("cp.seconds() <= 0 : {}", cp);


### PR DESCRIPTION
The AMI/HES system was getting stuck in infinite loops during event log collection because the "last read" timestamp in the `meter_profile_state` table was not advancing when a meter returned only duplicate or no data for a 24-hour window.

This PR implements a "jump and persist" mechanism for the following event profiles:
- Standard Event Log (all meters)
- Fraud Event Log (household meters)
- Control Event Log (household meters)
- Management Token Event Log (household meters)
- Recharge Token Event Log (household meters)

When a processing window (typically 1 day) is completed and yields no new records (either due to an empty response from the meter or deduplication against the database), the system now explicitly advances the persistent state to the end of that window. This allows the ingestion loop to progress to the next day rather than repeatedly querying the same historical window.

This change is restricted to event logs, which are sporadic by nature, ensuring that standard load profiles (Channels 1-3) and billing data remain subject to stricter timestamp-matching rules.

---
*PR created automatically by Jules for task [17350499833453656501](https://jules.google.com/task/17350499833453656501) started by @oluwin*