### PR TITLE
Refactor NetworkWriteService to support Non-MD meters with UINT32 Por…

### DIFF
--- a/hes/src/main/java/com/memmcol/hes/domain/network/NetworkWriteService.java
+++ b/hes/src/main/java/com/memmcol/hes/domain/network/NetworkWriteService.java
@@ -112,8 +112,9 @@ public class NetworkWriteService {
                 log.info("Writing Port {} then IP {} to Non-MD meter {}", port, ip, meterSerial);
 
                 // Fallback: Write Port first (Class 41, Attr 2), then IP (Class 45, Attr 5)
+                // Using UINT32 (double-long-unsigned) for Port to ensure hardware compatibility
                 response = dlmsReaderUtils.writeAttribute(client, meterSerial, "0.11.25.0.0.255", 41, 2,
-                        port, DataType.UINT16);
+                        (long) port, DataType.UINT32);
 
                 if (response.isSuccess()) {
                     response = dlmsReaderUtils.writeAttribute(client, meterSerial, "0.11.25.4.0.255", 45, 5,

--- a/hes/src/test/java/com/memmcol/hes/domain/network/NetworkWriteServiceTest.java
+++ b/hes/src/test/java/com/memmcol/hes/domain/network/NetworkWriteServiceTest.java
@@ -139,8 +139,8 @@ public class NetworkWriteServiceTest {
         assertEquals("success", result.get("status"));
         assertEquals(ipPorts, result.get("ipPorts"));
 
-        // Verify Port written first (Class 41, Attr 2)
-        verify(dlmsReaderUtils).writeAttribute(eq(dlmsClient), eq(serial), eq("0.11.25.0.0.255"), eq(41), eq(2), eq(port), eq(DataType.UINT16));
+        // Verify Port written first (Class 41, Attr 2) as UINT32
+        verify(dlmsReaderUtils).writeAttribute(eq(dlmsClient), eq(serial), eq("0.11.25.0.0.255"), eq(41), eq(2), eq((long)port), eq(DataType.UINT32));
         // Verify IP written second (Class 45, Attr 5)
         verify(dlmsReaderUtils).writeAttribute(eq(dlmsClient), eq(serial), eq("0.11.25.4.0.255"), eq(45), eq(5), any(byte[].class), eq(DataType.OCTET_STRING));
     }


### PR DESCRIPTION
…t fix

- Updated writeApn to use OBIS 0.11.25.4.0.255 for Non-MD meters.
- Updated writeIpPort to support Non-MD meters by parsing "IP:Port" and writing Port (Class 41, UINT32) then IP (Class 45, Octet String) in sequence.
- UINT32 (Tag 0x06) used for Port to ensure hardware compatibility as per diagnostic feedback.
- Injected MeterRepository into NetworkWriteService for meter class lookup.
- Enhanced NetworkWriteServiceTest with MD and Non-MD test cases verifying OBIS and Data Types.