### PR TITLE
Refactor network config and fix clock update response bug

### DIFF
--- a/hes/src/main/java/com/memmcol/hes/controller/DlmsController.java
+++ b/hes/src/main/java/com/memmcol/hes/controller/DlmsController.java
@@ -72,15 +72,11 @@ public class DlmsController {
             LocalDateTime dateTime) {
         Map<String, Object> response = new HashMap<>();
         try {
-            String message = dlmsService.setClock(serial, dateTime);
-            response.put("status", "success");
-            response.put("message", message);
-            response.put("serial", serial);
-            response.put("timestamp", LocalDateTime.now());
-            return ResponseEntity.ok(response);
+            Map<String, Object> data = dlmsService.setClock(serial, dateTime);
+            return ResponseEntity.ok(data);
         } catch (Exception e) {
             response.put("status", "error");
-            response.put("message", "Failed to set meter clock");
+            response.put("message", "Internal error while setting meter clock");
             response.put("details", e.getMessage());
             response.put("serial", serial);
             response.put("timestamp", LocalDateTime.now());

--- a/hes/src/main/java/com/memmcol/hes/domain/clock/ClockWriteService.java
+++ b/hes/src/main/java/com/memmcol/hes/domain/clock/ClockWriteService.java
@@ -15,6 +15,8 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -30,7 +32,7 @@ public class ClockWriteService {
      * @param serial   meter serial number
      * @param dateTime local date-time to set on the meter
      */
-    public String setClock(String serial, LocalDateTime dateTime) throws Exception {
+    public Map<String, Object> setClock(String serial, LocalDateTime dateTime) throws Exception {
         GXDLMSClient client = sessionManager.getOrCreateClient(serial);
         if (client == null) {
             throw new IllegalStateException("No DLMS session found for meter: " + serial);
@@ -38,22 +40,31 @@ public class ClockWriteService {
 
         GXDLMSClock clock = new GXDLMSClock("0.0.1.0.0.255");
 
+        // Gurux GXDateTime handles the complex DLMS structure (12-byte OCTET STRING)
         GXDateTime gxDateTime = new GXDateTime(Date.from(
                 dateTime.atZone(ZoneId.systemDefault()).toInstant()
         ));
 
         DlmsResponse response = dlmsReaderUtils.writeAttribute(client, serial, clock, 2, gxDateTime);
 
+        Map<String, Object> result = new HashMap<>();
+        result.put("serial", serial);
+        result.put("timestamp", LocalDateTime.now());
+
         String formatted = dateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
         if (response.isSuccess()) {
             String message = "🕒 Meter Clock for " + serial + " set to: " + formatted;
             log.info(message);
-            return message;
+            result.put("status", "success");
+            result.put("message", message);
         } else {
             String message = "❌ Failed to set Meter Clock for " + serial + ": " + response.getMessage() + " (" + response.getStatus() + ")";
             log.error(message);
-            return message;
+            result.put("status", "failed");
+            result.put("message", message);
+            result.put("dlmsStatus", response.getStatus());
         }
+        return result;
     }
 
     public String setClockV1(String serial, LocalDateTime dateTime) throws Exception {

--- a/hes/src/main/java/com/memmcol/hes/service/DlmsService.java
+++ b/hes/src/main/java/com/memmcol/hes/service/DlmsService.java
@@ -228,7 +228,7 @@ public class DlmsService {
         return strclock;
     }
 
-    public String setClock(String serial, LocalDateTime dateTime) throws Exception {
+    public Map<String, Object> setClock(String serial, LocalDateTime dateTime) throws Exception {
         return clockWriteService.setClock(serial, dateTime);
     }
 


### PR DESCRIPTION
- Supported Non-MD meters in NetworkWriteService with specific OBIS codes and write order (Port then IP).
- Encoded Port as UINT32 (double-long-unsigned) for hardware compatibility.
- Fixed DlmsController.setClock false-positive success bug.
- Improved ClockWriteService to return Map with explicit failure status.
- Added comprehensive unit tests for MD and Non-MD network writes.