### PR TITLE
Set token naming convention update

### DIFF
--- a/hes/src/main/java/com/memmcol/hes/domain/token/TokenService.java
+++ b/hes/src/main/java/com/memmcol/hes/domain/token/TokenService.java
@@ -38,7 +38,7 @@ public class TokenService {
     public static final int CREDIT_BALANCE_CLASS_ID = 3;
 
 
-    public Map<String, Object> writeToken(String meterSerial, String creditToken) throws Exception {
+    public Map<String, Object> writeToken(String meterSerial, String tokenHex) throws Exception {
         return meterLockPort.withExclusive(meterSerial, () -> {
             GXDLMSClient client = sessionManager.getOrCreateClient(meterSerial);
             if (client == null) {
@@ -50,10 +50,10 @@ public class TokenService {
             // 2. Define the Token Object
             GXDLMSData tokenObject = new GXDLMSData(TOKEN_OBIS);
 
-            log.info("Step 1: Writing credit token to meter {}", meterSerial);
-            log.debug("Token hex bytes: {}", GXCommon.hexToBytes(creditToken));
+            log.info("Step 1: Writing token to meter {}", meterSerial);
+            log.debug("Token hex bytes: {}", GXCommon.hexToBytes(tokenHex));
 
-            byte[] tokenBytes = GXCommon.hexToBytes(creditToken);
+            byte[] tokenBytes = GXCommon.hexToBytes(tokenHex);
 
             // 4. SET THE VALUE INSIDE THE OBJECT FIRST
             tokenObject.setValue(tokenBytes);
@@ -70,7 +70,7 @@ public class TokenService {
 
             Map<String, Object> result = new LinkedHashMap<>();
             result.put("meterSerial", meterSerial);
-            result.put("creditToken", creditToken);
+            result.put("token", tokenHex);
             result.put("status", tokenResult.isSuccess() ? "success" : "failed");
             result.put("dlmsStatus", response.getStatus());
             result.put("message", response.getMessage());

--- a/hes/src/main/resources/application-dev.properties
+++ b/hes/src/main/resources/application-dev.properties
@@ -1,6 +1,7 @@
 # Development profile: application-dev.properties
 spring.application.name=hes-service-dev
 nettyserver.port=29064
+  #29065
 
 hes.token.issuer=hes-admin
 hes.token.access.validity=1800000


### PR DESCRIPTION
Changing name from credit to token. Since, the service is meant to serve all aspect of token relation.